### PR TITLE
Add weekly summary report sent every Friday

### DIFF
--- a/claude_advisor/weekly_advisor.py
+++ b/claude_advisor/weekly_advisor.py
@@ -1,0 +1,123 @@
+"""Generate a weekly market narrative via Claude Haiku.
+
+Called on Fridays after the daily report. Sends the structured weekly summary
+to claude-haiku-4-5 and asks it to write a concise Portuguese debrief.
+Graceful: returns an empty string on any failure so the weekly email still
+sends without the narrative paragraph.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_MODEL = "claude-haiku-4-5-20251001"
+_MAX_TOKENS = 400   # narrative capped at ~800 chars ≈ 200-250 tokens; headroom for safety
+
+_SYSTEM = (
+    "Você é um analista sênior de mercados financeiros. "
+    "Escreva um resumo semanal conciso e perspicaz em português brasileiro. "
+    "Tom conversacional, como um debrief de sexta à tarde entre colegas. "
+    "Máximo 800 caracteres totais. Sem markdown, sem bullet points — apenas parágrafos."
+)
+
+_INSTRUCTION_TEMPLATE = """\
+Com base nos dados abaixo, escreva exatamente 3-4 parágrafos curtos em português:
+
+• Parágrafo 1: como evoluiu o contexto macro esta semana (Fear & Greed, Buffett)
+• Parágrafo 2: padrões dominantes (ex.: "metais preciosos mostraram atividade institucional persistente a semana toda")
+• Parágrafo 3: os sinais de maior destaque e o que podem indicar
+• Parágrafo 4: o que observar na próxima semana
+
+---
+{summary_text}
+"""
+
+
+def _build_summary_text(summary: dict) -> str:
+    """Flatten the structured summary into a compact prompt body."""
+    days = summary.get("days_analyzed", 0)
+    total = summary.get("total_signals", 0)
+    red = summary.get("red_alerts", [])
+    amber = summary.get("amber_alerts", [])
+    freq = summary.get("asset_frequency", {})
+    highest_vol = summary.get("highest_volume", [])
+    me = summary.get("macro_evolution", {})
+
+    fg_start = (me.get("fear_greed_start") or {}).get("score", "N/A")
+    fg_end = (me.get("fear_greed_end") or {}).get("score", "N/A")
+    buf_start_pct = (me.get("buffett_start") or {}).get("pct", "N/A")
+    buf_start_cls = (me.get("buffett_start") or {}).get("class", "")
+    buf_end_pct = (me.get("buffett_end") or {}).get("pct", "N/A")
+    buf_end_cls = (me.get("buffett_end") or {}).get("class", "")
+
+    top_assets = list(freq.items())[:6]
+
+    lines = [
+        f"Semana: {summary.get('week_start')} a {summary.get('week_end')}",
+        f"Dias analisados: {days} de 5 dias úteis",
+        f"Total de alertas: {total} ({len(red)} RED, {len(amber)} AMBER)",
+        "",
+        f"Ativos mais frequentes: {', '.join(f'{t} ({d}d)' for t, d in top_assets) or 'nenhum'}",
+        "",
+        "Maiores picos de volume da semana:",
+    ]
+    for v in highest_vol:
+        lines.append(f"  {v['ticker']} em {v['date']}: {v['ratio']:.1f}x")
+    if not highest_vol:
+        lines.append("  (sem dados)")
+
+    lines += [
+        "",
+        "Evolução macro:",
+        f"  Fear & Greed: início {fg_start}/100 → fim {fg_end}/100",
+        f"  Buffett: início {buf_start_pct}% ({buf_start_cls}) → fim {buf_end_pct}% ({buf_end_cls})",
+    ]
+    return "\n".join(lines)
+
+
+def generate_weekly_narrative(summary: dict, macro: dict) -> str:  # noqa: ARG001
+    """Call Claude Haiku and return a Portuguese weekly briefing string.
+
+    `macro` is accepted for interface consistency but the relevant macro data
+    is already embedded in `summary["macro_evolution"]`.
+
+    Returns an empty string on any failure (missing key, network error, etc.).
+    """
+    if not summary:
+        return ""
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        logger.warning("ANTHROPIC_API_KEY not set — skipping weekly narrative")
+        return ""
+
+    try:
+        import anthropic
+    except ImportError:
+        logger.warning("anthropic package not installed — skipping weekly narrative")
+        return ""
+
+    summary_text = _build_summary_text(summary)
+    user_content = _INSTRUCTION_TEMPLATE.format(summary_text=summary_text)
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model=_MODEL,
+            max_tokens=_MAX_TOKENS,
+            system=_SYSTEM,
+            messages=[{"role": "user", "content": user_content}],
+        )
+        narrative = response.content[0].text.strip()
+        logger.info(
+            f"weekly narrative generated: "
+            f"input={response.usage.input_tokens} "
+            f"output={response.usage.output_tokens} tokens"
+        )
+        return narrative
+    except Exception as e:
+        logger.warning(f"weekly narrative failed: {e}")
+        return ""

--- a/delivery/email_sender.py
+++ b/delivery/email_sender.py
@@ -362,7 +362,294 @@ def build_html_email(
 </html>"""
 
 
+# ── weekly helpers ─────────────────────────────────────────────────────────
+
+def _weekly_macro_card(macro_evolution: dict) -> str:
+    """Dark-theme card showing Fear & Greed and Buffett Indicator evolution."""
+    fg_start = (macro_evolution.get("fear_greed_start") or {}).get("score")
+    fg_end   = (macro_evolution.get("fear_greed_end")   or {}).get("score")
+    fg_start_date = (macro_evolution.get("fear_greed_start") or {}).get("date", "")
+    fg_end_date   = (macro_evolution.get("fear_greed_end")   or {}).get("date", "")
+
+    if fg_start is not None and fg_end is not None:
+        diff = fg_end - fg_start
+        arrow = "↑" if diff > 0 else "↓" if diff < 0 else "→"
+        diff_str = f"{'+' if diff > 0 else ''}{diff}"
+        fg_cell = (
+            f"<span style='color:{_fg_color(fg_start)};font-weight:700;'>{fg_start}/100</span>"
+            f"<span style='color:#64748b;'> ({fg_start_date})</span>"
+            f"<span style='color:#475569;'> {arrow} </span>"
+            f"<span style='color:{_fg_color(fg_end)};font-weight:700;'>{fg_end}/100</span>"
+            f"<span style='color:#64748b;'> ({fg_end_date})</span>"
+            f"<span style='color:#64748b;font-size:11px;'> &nbsp;{diff_str}</span>"
+        )
+    else:
+        fg_cell = "<span style='color:#64748b;'>unavailable</span>"
+
+    buf_start_pct = (macro_evolution.get("buffett_start") or {}).get("pct")
+    buf_end_pct   = (macro_evolution.get("buffett_end")   or {}).get("pct")
+    buf_end_cls   = (macro_evolution.get("buffett_end")   or {}).get("class", "")
+
+    if buf_start_pct is not None and buf_end_pct is not None:
+        bc = _buffett_color(buf_end_cls)
+        buf_diff = buf_end_pct - buf_start_pct
+        buf_cell = (
+            f"<span style='color:#94a3b8;'>{buf_start_pct:.0f}%</span>"
+            f" → "
+            f"<span style='color:{bc};font-weight:700;'>{buf_end_pct:.0f}% — {html.escape(buf_end_cls)}</span>"
+            f"<span style='color:#64748b;font-size:11px;'> &nbsp;({'+' if buf_diff >= 0 else ''}{buf_diff:.0f}pp)</span>"
+        )
+    else:
+        buf_cell = "<span style='color:#64748b;'>unavailable</span>"
+
+    rows = [("Fear &amp; Greed", fg_cell), ("Buffett Indicator", buf_cell)]
+    trs = "".join(
+        f"<tr>"
+        f"<td style='color:#94a3b8;padding:4px 14px 4px 0;font-size:12px;white-space:nowrap;vertical-align:middle;'>{label}</td>"
+        f"<td style='font-size:13px;padding:4px 0;vertical-align:middle;'>{value}</td>"
+        f"</tr>"
+        for label, value in rows
+    )
+    return (
+        f"<div style='background:#1e1e1e;border-radius:6px;padding:16px 20px;margin-bottom:14px;'>"
+        f"<div style='font-size:10px;font-weight:700;color:#64748b;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:10px;'>MACRO EVOLUTION</div>"
+        f"<table style='border-collapse:collapse;width:100%;'><tbody>{trs}</tbody></table>"
+        f"</div>"
+    )
+
+
+def _weekly_frequency_table(
+    asset_frequency: dict,
+    highest_volume: list[dict],
+    red_alerts: list[dict],
+    amber_alerts: list[dict],
+) -> str:
+    """Signal frequency table: ticker | days flagged | peak vol | tier."""
+    if not asset_frequency:
+        return (
+            "<div style='background:#1e1e1e;border-radius:6px;padding:14px 20px;"
+            "margin-bottom:14px;color:#64748b;font-style:italic;font-size:13px;'>"
+            "Nenhum alerta registrado esta semana.</div>"
+        )
+
+    red_set = {a["ticker"] for a in red_alerts}
+    amber_set = {a["ticker"] for a in amber_alerts}
+
+    vol_by_ticker: dict[str, float] = {}
+    for v in highest_volume:
+        t = v["ticker"]
+        if v["ratio"] > vol_by_ticker.get(t, 0.0):
+            vol_by_ticker[t] = v["ratio"]
+
+    header_style = (
+        "font-size:10px;font-weight:700;color:#64748b;text-transform:uppercase;"
+        "letter-spacing:.06em;padding:4px 10px 4px 0;"
+    )
+    rows_html = (
+        f"<tr>"
+        f"<th style='{header_style}'>Ativo</th>"
+        f"<th style='{header_style}text-align:right;'>Dias</th>"
+        f"<th style='{header_style}text-align:right;'>Vol pico</th>"
+        f"<th style='{header_style}text-align:right;'>Tier</th>"
+        f"</tr>"
+    )
+    for ticker, days in asset_frequency.items():
+        tier = "RED" if ticker in red_set else "AMBER"
+        tier_color = "#ef4444" if tier == "RED" else "#f97316"
+        peak_vol = vol_by_ticker.get(ticker)
+        vol_str = f"{peak_vol:.1f}x" if peak_vol else "—"
+        rows_html += (
+            f"<tr>"
+            f"<td style='font-size:13px;padding:4px 10px 4px 0;font-weight:600;'>{html.escape(ticker)}</td>"
+            f"<td style='font-size:13px;padding:4px 10px 4px 0;text-align:right;color:#94a3b8;'>{days}</td>"
+            f"<td style='font-size:13px;padding:4px 10px 4px 0;text-align:right;color:#94a3b8;'>{vol_str}</td>"
+            f"<td style='font-size:13px;padding:4px 0;text-align:right;'>"
+            f"<span style='color:{tier_color};font-weight:700;font-size:10px;'>{tier}</span>"
+            f"</td>"
+            f"</tr>"
+        )
+
+    return (
+        f"<div style='background:#1e1e1e;border-radius:6px;padding:16px 20px;margin-bottom:14px;'>"
+        f"<div style='font-size:10px;font-weight:700;color:#64748b;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:10px;'>FREQUÊNCIA DE SINAIS</div>"
+        f"<table style='border-collapse:collapse;width:100%;'><tbody>{rows_html}</tbody></table>"
+        f"</div>"
+    )
+
+
+def _weekly_volume_spikes(highest_volume: list[dict]) -> str:
+    """Top 3 volume spikes card."""
+    if not highest_volume:
+        return ""
+    items_html = ""
+    for i, v in enumerate(highest_volume[:3], 1):
+        items_html += (
+            f"<div style='display:flex;justify-content:space-between;align-items:center;"
+            f"padding:5px 0;border-bottom:1px solid #2d2d2d;'>"
+            f"<span style='font-size:13px;'>"
+            f"<span style='color:#94a3b8;margin-right:6px;'>#{i}</span>"
+            f"<span style='font-weight:700;'>{html.escape(v['ticker'])}</span>"
+            f"<span style='color:#64748b;font-size:11px;margin-left:8px;'>{v['date']}</span>"
+            f"</span>"
+            f"<span style='color:#ef4444;font-weight:700;font-size:14px;'>{v['ratio']:.1f}x</span>"
+            f"</div>"
+        )
+    return (
+        f"<div style='background:#1e1e1e;border-radius:6px;padding:16px 20px;margin-bottom:14px;'>"
+        f"<div style='font-size:10px;font-weight:700;color:#64748b;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:10px;'>TOP 3 PICOS DE VOLUME</div>"
+        f"{items_html}"
+        f"</div>"
+    )
+
+
+def _weekly_dynamic_changes(dynamic_changes: dict) -> str:
+    """Promoted/demoted tickers card. Omitted entirely if both lists are empty."""
+    promoted = dynamic_changes.get("promoted") or []
+    demoted  = dynamic_changes.get("demoted")  or []
+    if not promoted and not demoted:
+        return ""
+
+    def _badge_list(tickers: list[str], color: str, label: str) -> str:
+        if not tickers:
+            return ""
+        badges = "".join(
+            f"<span style='background:{color};color:#fff;font-size:11px;font-weight:700;"
+            f"padding:2px 8px;border-radius:3px;margin-right:4px;'>{html.escape(t)}</span>"
+            for t in tickers
+        )
+        return (
+            f"<div style='margin-bottom:8px;'>"
+            f"<span style='color:#64748b;font-size:11px;margin-right:8px;'>{label}</span>"
+            f"{badges}</div>"
+        )
+
+    content = _badge_list(promoted, "#22c55e", "Promovidos →") + _badge_list(demoted, "#ef4444", "Removidos →")
+    return (
+        f"<div style='background:#1e1e1e;border-radius:6px;padding:16px 20px;margin-bottom:14px;'>"
+        f"<div style='font-size:10px;font-weight:700;color:#64748b;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:10px;'>ALTERAÇÕES DE TICKERS</div>"
+        f"{content}"
+        f"</div>"
+    )
+
+
+def _weekly_narrative_card(narrative: str) -> str:
+    if not narrative:
+        return ""
+    return (
+        f"<div style='background:#1a2035;border-radius:6px;border-left:4px solid #3b82f6;"
+        f"padding:16px 20px;margin-bottom:14px;'>"
+        f"<div style='font-size:10px;font-weight:700;color:#64748b;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:10px;'>ANÁLISE SEMANAL</div>"
+        f"<div style='font-size:13px;line-height:1.65;color:#cbd5e1;white-space:pre-wrap;'>"
+        f"{html.escape(narrative)}"
+        f"</div>"
+        f"</div>"
+    )
+
+
+def build_weekly_html_email(
+    summary: dict,
+    narrative: str,
+    date: dt.date,
+) -> str:
+    week_start = summary.get("week_start", "")
+    week_end   = summary.get("week_end", date.isoformat())
+    days       = summary.get("days_analyzed", 0)
+    total      = summary.get("total_signals", 0)
+    me         = summary.get("macro_evolution", {})
+
+    macro_card     = _weekly_macro_card(me)
+    freq_table     = _weekly_frequency_table(
+        summary.get("asset_frequency", {}),
+        summary.get("highest_volume", []),
+        summary.get("red_alerts", []),
+        summary.get("amber_alerts", []),
+    )
+    vol_card       = _weekly_volume_spikes(summary.get("highest_volume", []))
+    dynamic_card   = _weekly_dynamic_changes(summary.get("dynamic_changes", {}))
+    narrative_card = _weekly_narrative_card(narrative)
+
+    days_note = f"{days} de 5 dias úteis analisados"
+
+    return f"""<!DOCTYPE html>
+<html lang="pt-BR">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0f0f0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#f1f5f9;">
+<div style="max-width:600px;margin:0 auto;padding:24px 16px;">
+
+  <div style="margin-bottom:20px;">
+    <div style="font-size:10px;font-weight:700;color:#475569;letter-spacing:.1em;text-transform:uppercase;margin-bottom:4px;">Artificial Price Radar</div>
+    <div style="font-size:22px;font-weight:700;color:#f1f5f9;">Resumo Semanal &mdash; {week_start} a {week_end}</div>
+    <div style="font-size:12px;color:#64748b;margin-top:4px;">{days_note} &middot; {total} alertas totais (RED+AMBER)</div>
+  </div>
+
+  {macro_card}
+
+  {freq_table}
+
+  {vol_card}
+
+  {dynamic_card}
+
+  {narrative_card}
+
+  <div style="margin-top:20px;font-size:10px;color:#374151;text-align:center;">
+    Gerado em {date.isoformat()} &middot; Artificial Price Radar
+  </div>
+
+</div>
+</body>
+</html>"""
+
+
 # ── public entry point ─────────────────────────────────────────────────────
+
+def send_weekly_report(
+    summary: dict,
+    narrative: str,
+    date: dt.date,
+) -> None:
+    """Send the weekly summary as a standalone HTML email.
+
+    Subject: [Radar] Weekly Summary — Week of {monday_date}
+    Raises EmailConfigError if SMTP credentials are absent.
+    """
+    sender, password, recipient = _load_config()
+
+    week_start = summary.get("week_start", date.isoformat())
+    html_body = build_weekly_html_email(summary=summary, narrative=narrative, date=date)
+
+    plain = (
+        f"[Radar] Resumo Semanal — {week_start} a {summary.get('week_end', date.isoformat())}\n\n"
+        f"Dias analisados: {summary.get('days_analyzed', 0)}\n"
+        f"Total de alertas: {summary.get('total_signals', 0)}\n\n"
+        f"Ativos mais frequentes:\n"
+        + "\n".join(
+            f"  {t}: {d}d" for t, d in (summary.get("asset_frequency") or {}).items()
+        )
+        + ("\n\n" + narrative if narrative else "")
+    )
+
+    msg = EmailMessage()
+    msg["Subject"] = f"[Radar] Weekly Summary — Week of {week_start}"
+    msg["From"]    = sender
+    msg["To"]      = recipient
+    msg.set_content(plain)
+    msg.add_alternative(html_body, subtype="html")
+
+    logger.info(f"sending weekly report (week of {week_start}) to {recipient}")
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as smtp:
+        smtp.ehlo()
+        smtp.starttls()
+        smtp.ehlo()
+        smtp.login(sender, password)
+        smtp.send_message(msg)
+    logger.info("weekly report email sent")
+
 
 def send_report(
     report_path: str | None = None,

--- a/main.py
+++ b/main.py
@@ -55,8 +55,10 @@ from config.ticker_manager import (
     record_trigger,
     remove_stale_dynamic,
 )
-from delivery.email_sender import EmailConfigError, send_report
+from claude_advisor.weekly_advisor import generate_weekly_narrative
+from delivery.email_sender import EmailConfigError, send_report, send_weekly_report
 from output.document_builder import get_alert_tier, get_tier_reason, write_document
+from output.weekly_summary import generate_weekly_summary
 
 load_dotenv()
 
@@ -69,6 +71,21 @@ logger = logging.getLogger("radar")
 
 LOGS_DIR = "logs"
 FULL_SESSION_MIN_HOURS = 6.0
+
+
+def should_send_weekly(date: dt.date, force: bool) -> bool:
+    """Return True when the weekly summary email should be sent.
+
+    Rules:
+    - Always on Friday (weekday 4).
+    - On Saturday/Sunday only when force=True (manual workflow_dispatch).
+    - Never on Mon-Thu even with force (not meaningful mid-week).
+    """
+    if date.weekday() == 4:
+        return True
+    if force and date.weekday() in (5, 6):
+        return True
+    return False
 
 
 def check_trading_day(date: dt.date) -> tuple[bool, str]:
@@ -463,6 +480,41 @@ def main(argv: list[str]) -> int:
             logger.exception("email send failed")
             print(f"Email send failed: {e}", file=sys.stderr)
             return 1
+
+    # ── Weekly summary (Fridays, or forced on weekends) ───────────────────
+    if send_email and should_send_weekly(date, force):
+        weekly_summary = generate_weekly_summary(LOGS_DIR, date)
+        if not weekly_summary:
+            logger.warning("weekly summary: no log data found — skipping weekly email")
+        else:
+            days = weekly_summary.get("days_analyzed", 0)
+            if days < 3:
+                logger.info(
+                    f"weekly summary: only {days} of 5 trading days found — "
+                    "sending with available data"
+                )
+            macro_context = {
+                "fear_greed": fear_greed,
+                "buffett": buffett,
+            }
+            narrative = generate_weekly_narrative(weekly_summary, macro_context)
+            if not narrative:
+                logger.info("weekly summary: sending without narrative (generation failed or skipped)")
+            try:
+                send_weekly_report(
+                    summary=weekly_summary,
+                    narrative=narrative,
+                    date=date,
+                )
+                logger.info("weekly summary sent")
+                print("Weekly summary sent.")
+            except EmailConfigError as e:
+                logger.warning(f"weekly email skipped: {e}")
+                print(f"Weekly email skipped: {e}")
+            except Exception as e:
+                logger.exception("weekly email send failed")
+                print(f"Weekly email send failed: {e}", file=sys.stderr)
+
     return 0
 
 

--- a/output/weekly_summary.py
+++ b/output/weekly_summary.py
@@ -1,0 +1,210 @@
+"""Parse the week's archived log files and build a structured weekly summary.
+
+Reads logs/YYYY-MM-DD.txt for each trading day (Mon-Fri) of the given week,
+extracts RED/AMBER alert data, volume spikes, and macro evolution, and returns
+a structured dict consumed by the email builder and narrative generator.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+# ── Log-parsing patterns ───────────────────────────────────────────────────
+
+_RE_FG = re.compile(r"Fear & Greed: (\d+)/100")
+_RE_BUFFETT = re.compile(r"Buffett Indicator: ([\d.]+)%\s*[—\-]+\s*([\w ]+?)\s*\(")
+_RE_RED = re.compile(r"\[RED\]:\s*(.*)")
+_RE_AMBER = re.compile(r"\[AMBER\]:\s*(.*)")
+
+# Matches rows in the [TICKER ALERT TIERS] section, e.g.:
+#   GC=F | 28.1x | +0.3 | +0.1 | 47 | RED: vol=28.1x (extreme >5x)
+_RE_TIER_ROW = re.compile(
+    r"^\s{1,6}(\S+)\s*\|\s*([\d.]+)x\s*\|\s*([+-]?[\d.]+)\s*\|\s*"
+    r"([+-]?[\d.]+)\s*\|\s*([\d.]+|N/A)\s*\|\s*(RED|AMBER|SKIP):",
+    re.MULTILINE,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _monday_of_week(date: dt.date) -> dt.date:
+    return date - dt.timedelta(days=date.weekday())
+
+
+def _parse_tickers(raw: str) -> list[str]:
+    if not raw or not raw.strip():
+        return []
+    return [t.strip() for t in raw.split(",") if t.strip() and t.strip().lower() != "none"]
+
+
+def _parse_log_file(path: str) -> dict | None:
+    """Parse a single daily log file.
+
+    Returns a dict with keys:
+        fear_greed_score, buffett_pct, buffett_class,
+        red_tickers, amber_tickers,
+        ticker_signals: {ticker: {vol_ratio, z30, z200, rsi, tier}}
+    Returns None if the file cannot be read or parsed at all.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        logger.warning(f"Cannot read log file: {path}")
+        return None
+
+    result: dict = {
+        "fear_greed_score": None,
+        "buffett_pct": None,
+        "buffett_class": None,
+        "red_tickers": [],
+        "amber_tickers": [],
+        "ticker_signals": {},
+    }
+
+    m = _RE_FG.search(text)
+    if m:
+        result["fear_greed_score"] = int(m.group(1))
+
+    m = _RE_BUFFETT.search(text)
+    if m:
+        result["buffett_pct"] = float(m.group(1))
+        result["buffett_class"] = m.group(2).strip()
+
+    m = _RE_RED.search(text)
+    if m:
+        result["red_tickers"] = _parse_tickers(m.group(1))
+
+    m = _RE_AMBER.search(text)
+    if m:
+        result["amber_tickers"] = _parse_tickers(m.group(1))
+
+    for row in _RE_TIER_ROW.finditer(text):
+        ticker, vol, z30, z200, rsi_raw, tier = row.groups()
+        rsi = None if rsi_raw.upper() == "N/A" else float(rsi_raw)
+        result["ticker_signals"][ticker] = {
+            "vol_ratio": float(vol),
+            "z30": float(z30),
+            "z200": float(z200),
+            "rsi": rsi,
+            "tier": tier.lower(),
+        }
+
+    return result
+
+
+# ── Public entry point ─────────────────────────────────────────────────────
+
+def generate_weekly_summary(logs_dir: str, week_end_date: dt.date) -> dict:
+    """Read Mon–Fri log files and return a structured weekly summary.
+
+    Returns an empty dict if no log files are found for the week (the caller
+    should log a warning and skip the weekly send in that case).
+
+    Returned keys
+    -------------
+    days_analyzed   : int — how many trading days had data
+    total_signals   : int — total RED+AMBER alerts across the week
+    asset_frequency : dict[str, int] — ticker → days it flagged (desc order)
+    highest_volume  : list[dict] — top 3: {ticker, date, ratio}
+    macro_evolution : dict — fg/buffett for first and last day
+    dynamic_changes : dict — {promoted: [], demoted: []} (not in log files)
+    red_alerts      : list[dict] — {ticker, date} for every RED alert
+    amber_alerts    : list[dict] — {ticker, date} for every AMBER alert
+    week_start      : str — ISO date of Monday
+    week_end        : str — ISO date of week_end_date
+    """
+    monday = _monday_of_week(week_end_date)
+    trading_days = [
+        monday + dt.timedelta(days=i)
+        for i in range(5)
+        if monday + dt.timedelta(days=i) <= week_end_date
+    ]
+
+    parsed: list[tuple[dt.date, dict]] = []
+    for day in trading_days:
+        log_path = os.path.join(logs_dir, f"{day.isoformat()}.txt")
+        if not os.path.isfile(log_path):
+            logger.info(f"weekly_summary: no log for {day.isoformat()} — skipping")
+            continue
+        data = _parse_log_file(log_path)
+        if data is not None:
+            parsed.append((day, data))
+
+    if not parsed:
+        logger.warning(f"weekly_summary: no log files found for week of {monday.isoformat()}")
+        return {}
+
+    # ── Asset frequency & alert lists ────────────────────────────────────
+    asset_days: dict[str, int] = {}
+    red_alerts: list[dict] = []
+    amber_alerts: list[dict] = []
+
+    for day, data in parsed:
+        seen_today: set[str] = set()
+        for ticker in data["red_tickers"]:
+            red_alerts.append({"ticker": ticker, "date": day.isoformat()})
+            if ticker not in seen_today:
+                asset_days[ticker] = asset_days.get(ticker, 0) + 1
+                seen_today.add(ticker)
+        for ticker in data["amber_tickers"]:
+            amber_alerts.append({"ticker": ticker, "date": day.isoformat()})
+            if ticker not in seen_today:
+                asset_days[ticker] = asset_days.get(ticker, 0) + 1
+                seen_today.add(ticker)
+
+    # ── Top volume spikes across all RED/AMBER tickers ────────────────────
+    volume_events: list[dict] = []
+    for day, data in parsed:
+        alert_tickers = set(data["red_tickers"] + data["amber_tickers"])
+        for ticker, sig in data["ticker_signals"].items():
+            if ticker in alert_tickers:
+                volume_events.append(
+                    {"ticker": ticker, "date": day.isoformat(), "ratio": sig["vol_ratio"]}
+                )
+    volume_events.sort(key=lambda x: x["ratio"], reverse=True)
+    highest_volume = volume_events[:3]
+
+    # ── Macro evolution ───────────────────────────────────────────────────
+    first_day, first_data = parsed[0]
+    last_day, last_data = parsed[-1]
+    macro_evolution = {
+        "fear_greed_start": {
+            "date": first_day.isoformat(),
+            "score": first_data["fear_greed_score"],
+        },
+        "fear_greed_end": {
+            "date": last_day.isoformat(),
+            "score": last_data["fear_greed_score"],
+        },
+        "buffett_start": {
+            "date": first_day.isoformat(),
+            "pct": first_data["buffett_pct"],
+            "class": first_data["buffett_class"],
+        },
+        "buffett_end": {
+            "date": last_day.isoformat(),
+            "pct": last_data["buffett_pct"],
+            "class": last_data["buffett_class"],
+        },
+    }
+
+    return {
+        "days_analyzed": len(parsed),
+        "total_signals": len(red_alerts) + len(amber_alerts),
+        "asset_frequency": dict(
+            sorted(asset_days.items(), key=lambda x: x[1], reverse=True)
+        ),
+        "highest_volume": highest_volume,
+        "macro_evolution": macro_evolution,
+        "dynamic_changes": {"promoted": [], "demoted": []},
+        "red_alerts": red_alerts,
+        "amber_alerts": amber_alerts,
+        "week_start": monday.isoformat(),
+        "week_end": week_end_date.isoformat(),
+    }


### PR DESCRIPTION
- output/weekly_summary.py: parse Mon-Fri log files to produce a
  structured dict (days_analyzed, total_signals, asset_frequency,
  highest_volume top 3, macro evolution, red/amber alert lists).
  Graceful: skips missing days, returns {} when no logs exist.

- claude_advisor/weekly_advisor.py: call claude-haiku-4-5-20251001
  to generate a 3-4 paragraph Portuguese briefing from the weekly
  summary. Returns "" on any failure so the email still sends.

- delivery/email_sender.py: add send_weekly_report() and matching
  HTML builder — same dark theme as daily email, with macro evolution
  card, signal frequency table, top-3 volume spikes, dynamic ticker
  changes, and the Claude narrative block at the bottom.

- main.py: add should_send_weekly() (Friday always; Sat/Sun only
  with --force) and wire the weekly block after the daily email send.
  Logs a warning and skips if no log data found; sends with a note
  if fewer than 3 days are available.

https://claude.ai/code/session_01Wcj9e47CdZztZppw4Q8Nwn