### PR TITLE
feat: add synthetic sentiment proxy for historical backtests

### DIFF
--- a/backtesting/historical/main.py
+++ b/backtesting/historical/main.py
@@ -32,10 +32,11 @@ logger = logging.getLogger(__name__)
 
 PERIODS: dict[str, dict] = {
     "covid_2020": {
-        "start":   "2020-02-01",
-        "end":     "2020-06-01",
-        "tickers": ["NVDA", "TSLA", "AAPL", "AMZN", "GOOGL", "GC=F", "SI=F", "CL=F", "HG=F"],
-        "name":    "COVID Crash & Recovery",
+        "start":       "2020-02-01",
+        "end":         "2020-06-01",
+        "tickers":     ["NVDA", "TSLA", "AAPL", "AMZN", "GOOGL", "GC=F", "SI=F", "CL=F", "HG=F"],
+        "name":        "COVID Crash & Recovery",
+        "vix_context": "VIX peaked at 82.69 on March 16, 2020 — highest since 2008",
     },
     "gamestop_2021": {
         "start":   "2021-01-01",

--- a/backtesting/historical/report_builder.py
+++ b/backtesting/historical/report_builder.py
@@ -96,23 +96,6 @@ def _hit_rate_table(hit_rates: dict) -> str:
         return "<p>No directional recommendations to evaluate.</p>"
 
     header = "<tr><th>Recommendation</th>" + "".join(
-        f"<th>d+{w} hit rate (n)</th>" for w in EVAL_WINDOWS
-    ) + "</tr>"
-
-    rows = []
-    for rec in recoms:
-        cells = f"<td><code>{rec}</code></td>"
-        for w in EVAL_WINDOWS:
-            entry = hit_rates.get(f"d{w}", {}).get(rec)
-            if entry and entry["total"] > 0:
-                cells += _pct_cell(entry["pct"]) + f"<td style='font-size:11px;color:#666'>{entry['hits']}/{entry['total']}</td>"
-            else:
-                cells += '<td class="na">—</td><td class="na">—</td>'
-        rows.append(f"<tr>{cells}</tr>")
-
-    # Merge the n columns into the pct column for cleaner layout
-    # Rebuild: one cell per window showing "60.0% (6/10)"
-    header = "<tr><th>Recommendation</th>" + "".join(
         f"<th>d+{w} hit rate</th>" for w in EVAL_WINDOWS
     ) + "</tr>"
     rows = []
@@ -130,7 +113,28 @@ def _hit_rate_table(hit_rates: dict) -> str:
                 cells += '<td class="na">—</td>'
         rows.append(f"<tr>{cells}</tr>")
 
-    return f'<table>{header}{"".join(rows)}</table>'
+    note = (
+        '<p style="font-size:12px;color:#666;margin-top:8px;">'
+        '* Confidence scores shown are post-penalty '
+        '(Claude raw confidence &minus; 2 applied by runner before saving).'
+        '</p>'
+    )
+    return f'<table>{header}{"".join(rows)}</table>{note}'
+
+
+def _vix_timeline(vix_timeline: dict | None) -> str:
+    if not vix_timeline:
+        return "<p>VIX data not available for this backtest period.</p>"
+    rows = [
+        f"<tr><td>Min VIX</td><td>{vix_timeline.get('min', '—')}</td></tr>",
+        f"<tr><td>Max VIX</td><td>{vix_timeline.get('max', '—')}</td></tr>",
+        f"<tr><td>Avg VIX</td><td>{vix_timeline.get('avg', '—')}</td></tr>",
+        f"<tr><td>Days VIX ≥ 35 (elevated heat)</td><td>{vix_timeline.get('days_above_35', 0)}</td></tr>",
+        f"<tr><td>Days VIX ≥ 50 (explosive heat)</td><td>{vix_timeline.get('days_above_50', 0)}</td></tr>",
+    ]
+    return (
+        f'<table><tr><th>Metric</th><th>Value</th></tr>{"".join(rows)}</table>'
+    )
 
 
 def _best_worst_table(signals: list[dict], best: bool, n: int = 5) -> str:
@@ -276,16 +280,23 @@ def generate_html_report(results: dict) -> str:
   <div class="sub">{start} → {end} &nbsp;|&nbsp; {len(results.get('tickers',[]))} tickers</div>
   {_stat_grid(results)}
   <div class="note">
-    ⚠ No sentiment data available for historical periods — technical signals only
-    (volume, price velocity, RSI). Social-heat-based Divergence Rules were not applied.
-    Macro context (Fear &amp; Greed, VIX, Buffett) was marked unavailable in each prompt.
+    ⚠ Sentiment derived from VIX proxy. Confidence scores reduced by 2 to account for proxy uncertainty.
+    Social-heat-based Divergence Rules applied using VIX as a substitute for real social data
+    (Reddit, StockTwits, YouTube). Fear &amp; Greed index derived from VIX (inverse relationship).
   </div>
   {cap_warning}
 </div>
 
 <div class="card">
   <h2>Hit Rate by Recommendation Type</h2>
+  <div class="sub">Confidence scores shown are post-penalty (raw Claude confidence &minus; 2)</div>
   {_hit_rate_table(hr)}
+</div>
+
+<div class="card">
+  <h2>VIX Timeline</h2>
+  <div class="sub">VIX used as proxy for social sentiment heat — high VIX = high synthetic heat</div>
+  {_vix_timeline(results.get("vix_timeline"))}
 </div>
 
 <div class="card">

--- a/backtesting/historical/runner.py
+++ b/backtesting/historical/runner.py
@@ -31,6 +31,7 @@ import yfinance as yf
 from analyzers.price_velocity import analyze_price_velocity
 from analyzers.rsi import analyze_rsi
 from analyzers.volume_analyzer import analyze_volume
+from backtesting.historical.sentiment_proxy import get_synthetic_sentiment, vix_to_fear_greed
 from claude_advisor.prompts import SYSTEM_PROMPT
 from output.document_builder import get_alert_tier
 from utils.token_optimizer import compress_signals
@@ -44,12 +45,22 @@ BULLISH = {"contrarian_buy"}
 BEARISH = {"reduce_exposure"}
 MAX_CLAUDE_CALLS = 200
 
-# Appended to every historical prompt so Claude knows macro context is absent.
-_MACRO_UNAVAILABLE = (
-    "\n\nMacro context for this date: unavailable — historical backtest. "
-    "No live Fear & Greed, VIX structure, or Buffett Indicator data. "
-    "Apply base classification logic without macro adjustments."
-)
+# Appended to the system prompt on every historical backtest call.
+HISTORICAL_MODE_ADDENDUM = """
+## Historical Backtest Mode
+
+You are analyzing historical data. Real social sentiment (Reddit, StockTwits, YouTube) is not available.
+Instead, a VIX-based synthetic proxy has been provided:
+- VIX ≥ 50 → treat as "explosive" social heat (extreme panic period)
+- VIX ≥ 35 → treat as "elevated" social heat
+- VIX ≥ 25 → treat as "stable"
+- VIX < 25 → treat as "low"
+
+Apply the same Divergence Rules as normal but using this proxy.
+Apply the confidence_penalty indicated — reduce your raw confidence by that amount before outputting.
+Your classification and recommendation logic is unchanged."""
+
+_VIX_DEFAULT = 20.0
 
 # Extra calendar days fetched before start for 200d lookback warmup
 _LOOKBACK_BUFFER = 310
@@ -183,7 +194,11 @@ def _call_claude(
                     "type": "text",
                     "text": SYSTEM_PROMPT,
                     "cache_control": {"type": "ephemeral"},
-                }
+                },
+                {
+                    "type": "text",
+                    "text": HISTORICAL_MODE_ADDENDUM,
+                },
             ],
             messages=[{"role": "user", "content": prompt_text}],
         )
@@ -340,7 +355,25 @@ def run_historical_backtest(
     trading_days = _trading_days(start_date, end_date)
     logger.info("%d trading days in range", len(trading_days))
 
-    # --- 2. Fetch OHLCV for all tickers ----------------------------------------
+    # --- 2. Fetch VIX history for synthetic sentiment proxy --------------------
+    logger.info("Fetching VIX history for %s → %s ...", start_date, end_date)
+    vix_by_date: dict[dt.date, float] = {}
+    try:
+        vix_df = yf.download("^VIX", start=start_date, end=end_date, progress=False)
+        if not vix_df.empty:
+            if isinstance(vix_df.columns, pd.MultiIndex):
+                close_col = vix_df[("Close", "^VIX")]
+            else:
+                close_col = vix_df["Close"]
+            for ts, val in close_col.items():
+                d = ts.date() if hasattr(ts, "date") else ts.to_pydatetime().date()
+                if pd.notna(val):
+                    vix_by_date[d] = float(val)
+        logger.info("VIX history loaded: %d dates", len(vix_by_date))
+    except Exception as exc:
+        logger.warning("VIX fetch failed (%s) — using default VIX=%.1f for all dates", exc, _VIX_DEFAULT)
+
+    # --- 3. Fetch OHLCV for all tickers ----------------------------------------
     ticker_dfs: dict[str, pd.DataFrame] = {}
     for ticker in tickers:
         logger.info("Fetching %s ...", ticker)
@@ -365,7 +398,7 @@ def run_historical_backtest(
         rets[1:][mask] = (closes[1:][mask] - prev[mask]) / prev[mask]
         ticker_returns[ticker] = rets
 
-    # --- 3. Main loop: signals + Claude calls ----------------------------------
+    # --- 4. Main loop: signals + Claude calls ----------------------------------
     all_signals: list[dict] = []
     total_claude_calls = 0
     total_usage = {
@@ -428,10 +461,33 @@ def run_historical_backtest(
                 cap_reached = True
                 break
 
+            # --- Synthetic sentiment + macro proxy ----------------------------
+            vix_value = vix_by_date.get(day, _VIX_DEFAULT)
+            synth     = get_synthetic_sentiment(
+                ticker=ticker,
+                date=day,
+                vix_value=vix_value,
+                z_30d=velocity["z_score_30d"],
+                z_200d=velocity["z_score_200d"],
+                volume_ratio=volume["ratio"],
+                rsi=rsi.get("rsi"),
+            )
+            fg_proxy = vix_to_fear_greed(vix_value)
+
+            macro_section = (
+                f"\n\nMacro context (historical proxy):\n"
+                f"- Fear & Greed proxy (VIX-derived): {fg_proxy}/100\n"
+                f"- Synthetic Sentiment (VIX-proxy): heat={synth['heat']}, tone={synth['tone']}\n"
+                f"- VIX on this date: {vix_value:.1f}\n"
+                f"- Confidence penalty: {synth['confidence_penalty']} "
+                f"(reduce your output confidence by this amount)\n"
+                f"- Note: sentiment derived from VIX proxy, not real social data. "
+                f"Confidence should reflect this uncertainty."
+            )
+
             # --- Claude call ---------------------------------------------------
             name        = _ticker_name(ticker)
-            # Append macro-unavailable note so Claude skips macro adjustments.
-            prompt_text = compress_signals(ticker, name, signals) + _MACRO_UNAVAILABLE
+            prompt_text = compress_signals(ticker, name, signals) + macro_section
             logger.info("Calling Claude: %s %s (call %d/%d)", ticker, day,
                         total_claude_calls + 1, MAX_CLAUDE_CALLS)
             parsed, usage = _call_claude(client, prompt_text)
@@ -440,20 +496,30 @@ def run_historical_backtest(
             for k in total_usage:
                 total_usage[k] += usage.get(k, 0)
 
+            # Apply confidence penalty before storing (synthetic proxy is less reliable)
+            raw_confidence = parsed.get("confidence", 0) if parsed else 0
+            penalty        = synth["confidence_penalty"]
+            stored_confidence = max(1, raw_confidence - penalty) if raw_confidence > 0 else 0
+
             all_signals.append({
-                "ticker":          ticker,
-                "date":            day.isoformat(),
-                "tier":            tier,
-                "classification":  parsed.get("classification", "ambiguous") if parsed else "error",
-                "recommendation":  parsed.get("recommendation", "no_action")  if parsed else "error",
-                "confidence":      parsed.get("confidence", 0)                if parsed else 0,
-                "reasoning":       parsed.get("reasoning", "")                if parsed else "",
-                "price_at_signal": market_data["current_price"],
-                "volume_ratio":    volume["ratio"],
-                "z_score_30d":     velocity["z_score_30d"],
-                "z_score_200d":    velocity["z_score_200d"],
-                "rsi":             rsi.get("rsi"),
-                "macro_extreme":   velocity["macro_extreme"],
+                "ticker":            ticker,
+                "date":              day.isoformat(),
+                "tier":              tier,
+                "classification":    parsed.get("classification", "ambiguous") if parsed else "error",
+                "recommendation":    parsed.get("recommendation", "no_action")  if parsed else "error",
+                "confidence":        stored_confidence,
+                "confidence_raw":    raw_confidence,
+                "reasoning":         parsed.get("reasoning", "")                if parsed else "",
+                "price_at_signal":   market_data["current_price"],
+                "volume_ratio":      volume["ratio"],
+                "z_score_30d":       velocity["z_score_30d"],
+                "z_score_200d":      velocity["z_score_200d"],
+                "rsi":               rsi.get("rsi"),
+                "macro_extreme":     velocity["macro_extreme"],
+                "vix_at_signal":     vix_value,
+                "synth_heat":        synth["heat"],
+                "synth_tone":        synth["tone"],
+                "fear_greed_proxy":  fg_proxy,
             })
 
             day_signal_count += 1
@@ -470,14 +536,31 @@ def run_historical_backtest(
         )
     logger.info("Total signals: %d  Claude calls: %d", len(all_signals), total_claude_calls)
 
-    # --- 4. Outcomes -----------------------------------------------------------
+    # --- 5. Outcomes -----------------------------------------------------------
     logger.info("Fetching outcome prices ...")
     all_signals = _evaluate_outcomes(all_signals, ticker_arrays)
 
-    # --- 5. Hit rates ----------------------------------------------------------
+    # --- 6. Hit rates ----------------------------------------------------------
     hit_rates = _calculate_hit_rates(all_signals)
 
-    # --- 6. Save ---------------------------------------------------------------
+    # --- 7. VIX timeline summary -----------------------------------------------
+    trading_day_vix = [vix_by_date.get(d, _VIX_DEFAULT) for d in trading_days]
+    vix_timeline: dict = {}
+    if trading_day_vix:
+        vix_timeline = {
+            "min":           round(min(trading_day_vix), 2),
+            "max":           round(max(trading_day_vix), 2),
+            "avg":           round(sum(trading_day_vix) / len(trading_day_vix), 2),
+            "days_above_35": sum(1 for v in trading_day_vix if v >= 35),
+            "days_above_50": sum(1 for v in trading_day_vix if v >= 50),
+        }
+        logger.info(
+            "VIX timeline: min=%.1f max=%.1f avg=%.1f days≥35=%d days≥50=%d",
+            vix_timeline["min"], vix_timeline["max"], vix_timeline["avg"],
+            vix_timeline["days_above_35"], vix_timeline["days_above_50"],
+        )
+
+    # --- 8. Save ---------------------------------------------------------------
     results = {
         "period_name":             period_name,
         "start_date":              start_date,
@@ -489,6 +572,7 @@ def run_historical_backtest(
         "cap_reached":             cap_reached,
         "token_usage":             total_usage,
         "hit_rates":               hit_rates,
+        "vix_timeline":            vix_timeline,
         "signals":                 all_signals,
     }
 

--- a/backtesting/historical/sentiment_proxy.py
+++ b/backtesting/historical/sentiment_proxy.py
@@ -1,0 +1,77 @@
+"""Synthetic sentiment proxy for historical backtests.
+
+Real social data (Reddit, StockTwits, YouTube) is not available for historical
+periods. This module derives a proxy from VIX + price velocity + RSI so the
+Divergence Rules in the system prompt can still fire during backtests.
+"""
+
+from __future__ import annotations
+
+
+def get_synthetic_sentiment(
+    ticker: str,
+    date: object,
+    vix_value: float,
+    z_30d: float,
+    z_200d: float,
+    volume_ratio: float,
+    rsi: float | None,
+) -> dict:
+    """Return a synthetic sentiment dict compatible with real sentiment format.
+
+    Parameters
+    ----------
+    ticker       : Asset ticker (reserved for future per-asset overrides).
+    date         : Signal date (reserved for future per-date overrides).
+    vix_value    : VIX close on this date; use 20.0 if unavailable.
+    z_30d        : 30-day price velocity z-score.
+    z_200d       : 200-day price velocity z-score (kept for interface symmetry).
+    volume_ratio : Current volume / 30d average (kept for interface symmetry).
+    rsi          : RSI-14 value, or None if history is too short.
+
+    Returns
+    -------
+    dict with keys: heat, tone, source, confidence_penalty
+    """
+    # VIX-based heat (primary signal)
+    if vix_value >= 50:
+        heat = "explosive"
+    elif vix_value >= 35:
+        heat = "elevated"
+    elif vix_value >= 25:
+        heat = "stable"
+    else:
+        heat = "low"
+
+    # Tone from price velocity + RSI
+    rsi_val = rsi if rsi is not None else 50.0
+    if z_30d < -1.5 and rsi_val < 40:
+        tone = "bearish"
+    elif z_30d > 1.5 and rsi_val > 60:
+        tone = "bullish"
+    else:
+        tone = "neutral"
+
+    return {
+        "heat":               heat,
+        "tone":               tone,
+        "source":             "synthetic_proxy",
+        "confidence_penalty": 2,
+    }
+
+
+def vix_to_fear_greed(vix: float) -> int:
+    """Derive a Fear & Greed index proxy from VIX (inverse relationship).
+
+    High VIX = extreme fear = low score.
+    """
+    if vix >= 50:
+        return 10   # Extreme Fear
+    elif vix >= 35:
+        return 25   # Fear
+    elif vix >= 25:
+        return 45   # Neutral
+    elif vix >= 18:
+        return 65   # Greed
+    else:
+        return 80   # Extreme Greed


### PR DESCRIPTION
Implements a VIX-based synthetic sentiment proxy so Divergence Rules
fire during historical backtests where real social data is absent.

- New file sentiment_proxy.py: get_synthetic_sentiment() maps VIX to
  heat (explosive/elevated/stable/low) and z_30d+RSI to tone
  (bearish/bullish/neutral); vix_to_fear_greed() derives F&G proxy
- runner.py: fetches ^VIX history at backtest start; builds macro
  section per day with heat, tone, VIX value, F&G proxy, and
  confidence_penalty; appends HISTORICAL_MODE_ADDENDUM to system
  prompt (second non-cached block); applies -2 confidence penalty
  before storing; stores vix_at_signal, synth_heat, synth_tone,
  fear_greed_proxy, confidence_raw alongside each signal; computes
  vix_timeline (min/max/avg/days≥35/days≥50) in results JSON
- report_builder.py: updated main note to describe VIX proxy; added
  VIX Timeline card; hit rate table now notes post-penalty scores
- main.py: added vix_context to covid_2020 period

https://claude.ai/code/session_019SMwrpGwZtLgzXu1RBvvtB