### PR TITLE
Add two new historical backtest periods: tech_bear_2022 and financial_crisis_2008

### DIFF
--- a/.github/workflows/historical_backtest.yml
+++ b/.github/workflows/historical_backtest.yml
@@ -12,6 +12,8 @@ on:
         options:
           - covid_2020
           - gamestop_2021
+          - tech_bear_2022
+          - financial_crisis_2008
 
 jobs:
   backtest:

--- a/backtesting/historical/main.py
+++ b/backtesting/historical/main.py
@@ -44,6 +44,20 @@ PERIODS: dict[str, dict] = {
         "tickers": ["GME", "AMC", "BB", "PLTR", "GC=F", "SI=F", "TSLA", "NVDA"],
         "name":    "GameStop & Silver Squeeze",
     },
+    "tech_bear_2022": {
+        "start":       "2021-11-01",
+        "end":         "2022-12-31",
+        "tickers":     ["NVDA", "TSLA", "AAPL", "AMZN", "GOOGL", "MSTR", "PLTR", "GC=F", "SI=F"],
+        "name":        "2022 Tech Bear Market",
+        "vix_context": "VIX peaked at 38.94 on March 7, 2022. Extended bear market — S&P dropped 27%, NASDAQ dropped 35%, TSLA dropped 73%, NVDA dropped 66% from peak.",
+    },
+    "financial_crisis_2008": {
+        "start":       "2008-09-01",
+        "end":         "2009-04-01",
+        "tickers":     ["AAPL", "AMZN", "GOOGL", "GC=F", "SI=F", "CL=F", "HG=F"],
+        "name":        "2008 Global Financial Crisis",
+        "vix_context": "VIX peaked at 89.53 on October 24, 2008 — highest ever recorded. Lehman Brothers collapsed September 15, 2008. S&P dropped 57% peak to trough. Market bottomed March 6, 2009.",
+    },
 }
 
 


### PR DESCRIPTION
- tech_bear_2022: November 2021–December 2022 tracking the 14-month tech downtrend
  (VIX peaked at 38.94 on March 7, 2022). Includes MSTR and PLTR as extreme bubble/crash cases.
  All tickers available by November 2021; excludes RDDT (IPO March 2024).

- financial_crisis_2008: September 2008–April 2009 covering the peak panic period
  (VIX peaked at 89.53 on October 24, 2008 — highest ever). Includes only tickers
  that were publicly traded in 2008; excludes NVDA, TSLA, PLTR, MSTR, RKLB, ASTS, SOFI, RDDT.

Update workflow dropdown to include both new periods.

https://claude.ai/code/session_01WbuvMcUcGEe7wQc4tfZcVE