### PR TITLE
fix: remove double confidence penalty + expand SECTOR_MAP for backtest coverage

### DIFF
--- a/backtesting/historical/runner.py
+++ b/backtesting/historical/runner.py
@@ -59,8 +59,9 @@ Instead, a VIX-based synthetic proxy has been provided:
 - VIX < 25 → treat as "low"
 
 Apply the same Divergence Rules as normal but using this proxy.
-Apply the confidence_penalty indicated — reduce your raw confidence by that amount before outputting.
-Your classification and recommendation logic is unchanged."""
+Your classification and recommendation logic is unchanged.
+Output your raw confidence score as normal; a post-processing adjustment will be applied in code
+to reflect the lower reliability of VIX-derived sentiment vs. real social data."""
 
 _VIX_DEFAULT = 20.0
 
@@ -580,8 +581,6 @@ def run_historical_backtest(
                 f"- Fear & Greed proxy (VIX-derived): {fg_proxy}/100\n"
                 f"- Synthetic Sentiment (VIX-proxy): heat={synth['heat']}, tone={synth['tone']}\n"
                 f"- VIX on this date: {vix_value:.1f}\n"
-                f"- Confidence penalty: {synth['confidence_penalty']} "
-                f"(reduce your output confidence by this amount)\n"
                 f"- Note: sentiment derived from VIX proxy, not real social data. "
                 f"Confidence should reflect this uncertainty."
             )

--- a/tracker/sectors.py
+++ b/tracker/sectors.py
@@ -3,14 +3,52 @@
 from __future__ import annotations
 
 SECTOR_MAP = {
-    "semis": ["NVDA", "AMD", "INTC", "MU", "SMCI", "ARM", "POET", "SNDK", "NBIS", "SOUN"],
-    "fintech": ["SOFI", "HOOD", "COIN", "MSTR"],
-    "mega_tech": ["AAPL", "MSFT", "GOOGL", "META", "AMZN"],
-    "commodities_metals": ["GC=F", "SI=F", "HG=F"],
-    "energy": ["CL=F", "NG=F"],
-    "agri": ["ZS=F"],
-    "meme_retail": ["GME", "RDDT", "PLTR", "RKLB", "ASTS"],
-    "etfs_broad": ["SPY", "QQQ"],
+    "semis": [
+        "NVDA", "AMD", "INTC", "MU", "SMCI", "ARM", "POET",
+        "SNDK", "NBIS", "SOUN", "TSM", "AVGO", "QCOM", "MRVL",
+        "ASML", "AMAT", "LRCX", "KLAC",
+    ],
+    "fintech": [
+        "SOFI", "HOOD", "COIN", "MSTR", "PYPL", "SQ", "AFRM",
+        "UPST", "LC", "NU",
+    ],
+    "mega_tech": [
+        "AAPL", "MSFT", "GOOGL", "GOOG", "META", "AMZN", "TSLA",
+        "NFLX", "ORCL", "CRM",
+    ],
+    "commodities_metals": [
+        "GC=F", "SI=F", "HG=F", "PL=F", "PA=F",
+        "GLD", "SLV", "GDX", "GDXJ",
+    ],
+    "energy": [
+        "CL=F", "NG=F", "BZ=F", "RB=F",
+        "XOM", "CVX", "COP", "OXY", "USO", "XLE",
+    ],
+    "agri": [
+        "ZS=F", "ZC=F", "ZW=F", "KC=F", "SB=F", "CC=F",
+        "DBA", "MOO",
+    ],
+    "meme_retail": [
+        "GME", "RDDT", "PLTR", "RKLB", "ASTS", "AMC", "BB",
+        "BBBY", "KOSS", "EXPR",
+    ],
+    "etfs_broad": [
+        "SPY", "QQQ", "IWM", "DIA", "VTI", "VOO",
+    ],
+    "biotech": [
+        "MRNA", "BNTX", "PFE", "JNJ", "GILD", "AMGN", "REGN", "VRTX",
+        "XBI", "IBB",
+    ],
+    "china_tech": [
+        "BABA", "JD", "PDD", "BIDU", "NIO", "XPEV", "LI",
+        "KWEB", "FXI",
+    ],
+    # MSTR and COIN already appear in fintech; crypto_proxies covers the
+    # remaining pure-play mining and spot/futures tickers.
+    "crypto_proxies": [
+        "MARA", "RIOT", "CLSK", "HUT",
+        "BTC-USD", "ETH-USD", "GBTC", "BITO",
+    ],
 }
 
 DIRECTION_GROUPS = {


### PR DESCRIPTION
## Summary

Two definitive root causes from `backtests/VALIDATION_DIAGNOSTIC_20260507.md`, fixed in a single commit.

---

## Fix 1 — Double confidence penalty (`backtesting/historical/runner.py`)

**Root cause:** The confidence penalty was applied twice:
1. `HISTORICAL_MODE_ADDENDUM` told Claude to _"reduce your raw confidence by that amount before outputting"_
2. Python line 603 then subtracted the penalty again from Claude's already-penalized output

Effective threshold for `contrarian_buy` (which requires `confidence ≥ 7`) was **raw internal ≥ 9** — reserved by the system prompt for "rare, high-conviction moments." Almost never fired in practice → zero directional signals → `_calculate_hit_rates()` accumulated nothing → every cell showed `—`.

**Change:** Removed both prompt-side penalty instructions. The Python-side application on line 603 is unchanged:
```python
stored_confidence = max(1, raw_confidence - penalty)   # applied once, in code
```

```diff
-Apply the confidence_penalty indicated — reduce your raw confidence by that amount before outputting.
-Your classification and recommendation logic is unchanged.
+Your classification and recommendation logic is unchanged.
+Output your raw confidence score as normal; a post-processing adjustment will be applied in code
+to reflect the lower reliability of VIX-derived sentiment vs. real social data.
```

```diff
-f"- Confidence penalty: {synth['confidence_penalty']} "
-f"(reduce your output confidence by this amount)\n"
```

**Effect:** Claude now outputs raw confidence. `contrarian_buy` fires when raw ≥ 7 (was effectively ≥ 9). Historical signals will produce real directional recommendations and non-null hit rates.

---

## Fix 2 — SECTOR_MAP coverage gaps (`tracker/sectors.py`)

**Root cause:** Historical backtest tickers didn't map to any sector, causing `get_sector()` to return `None` and the cluster detector to silently skip them.

Critical gaps:
- `TSLA` — unmapped; silently skipped in 3 of 4 backtest periods
- `AMC`, `BB` — unmapped; `meme_retail` had only GME + PLTR = 2 tickers from GameStop 2021's universe, making it **structurally impossible** to reach the 3-ticker cluster threshold
- GameStop 2021 had no sector with ≥ 3 mapped tickers at all

**Change:** Expanded all 8 existing sectors + added 3 new sectors:

| Sector | Key additions |
|--------|--------------|
| `mega_tech` | TSLA, GOOG, NFLX, ORCL, CRM |
| `meme_retail` | AMC, BB, BBBY, KOSS, EXPR |
| `semis` | TSM, AVGO, QCOM, MRVL, ASML, AMAT, LRCX, KLAC |
| `fintech` | PYPL, SQ, AFRM, UPST, LC, NU |
| `commodities_metals` | PL=F, PA=F, GLD, SLV, GDX, GDXJ |
| `energy` | BZ=F, RB=F, XOM, CVX, COP, OXY, USO, XLE |
| `agri` | ZC=F, ZW=F, KC=F, SB=F, CC=F, DBA, MOO |
| `etfs_broad` | IWM, DIA, VTI, VOO |
| `biotech` _(new)_ | MRNA, BNTX, PFE, JNJ, GILD, AMGN, REGN, VRTX, XBI, IBB |
| `china_tech` _(new)_ | BABA, JD, PDD, BIDU, NIO, XPEV, LI, KWEB, FXI |
| `crypto_proxies` _(new)_ | MARA, RIOT, CLSK, HUT, BTC-USD, ETH-USD, GBTC, BITO |

**Note on duplicates:** `MSTR` and `COIN` already appear in `fintech`. `get_sector()` returns the first match, so they stay in `fintech`. `crypto_proxies` covers the remaining pure-play mining and spot/futures tickers.

**Effect:** GameStop 2021 now has `meme_retail` = GME + AMC + BB = 3 tickers, enabling cluster detection for that period. TSLA signals now contribute to `mega_tech` cluster detection across 3 backtest periods.

---

## Risk assessment

| Concern | Assessment |
|---------|-----------|
| Production daily pipeline | Not affected. `CLUSTER_BOOST_ENABLED=false` (unchanged); cluster code never runs in production |
| Existing cached backtest results | Any `.json` in `backtesting/historical/results/` produced by the broken run should be deleted before re-running — they contain zero directional signals and are not comparable to post-fix results |
| `get_sector()` returning wrong sector | `MSTR`/`COIN` stay in `fintech` (first match wins); no ticker appears in two sectors |
| Unit tests | All 5 cluster-detector tests pass (`pytest tests/test_cluster_detector.py`) |

---

## After merging: re-run validation

1. Merge this PR
2. Delete any stale `.json` files under `backtesting/historical/results/`
3. Go to **Actions → Cluster Boost Validation → Run workflow**
   - Smoke test: **UNCHECKED**
   - Force re-run: **CHECKED** (ensures no stale cache)
   - Period: blank (all 4)
4. Expect: non-null hit rates for all periods; boosted_count > 0 for at least COVID, 2022 Bear, and 2008 (GameStop: now structurally possible with AMC + BB added)

https://claude.ai/code/session_019qwS7865mTbFaGg9p4fDRX

---
_Generated by [Claude Code](https://claude.ai/code/session_019qwS7865mTbFaGg9p4fDRX)_