### PR TITLE
fix: input quality (volume sanity, n/a heat, suspicious flags)

### DIFF
--- a/analyzers/volume_analyzer.py
+++ b/analyzers/volume_analyzer.py
@@ -8,7 +8,7 @@ def analyze_volume(market_data: dict) -> dict:
     baseline = market_data["avg_volume_30d"]
 
     if baseline <= 0:
-        return {"classification": "normal", "ratio": 0.0}
+        return {"classification": "normal", "ratio": 0.0, "data_quality": "ok"}
 
     ratio = current / baseline
     if ratio < 1.5:
@@ -20,4 +20,5 @@ def analyze_volume(market_data: dict) -> dict:
     else:
         classification = "extreme"
 
-    return {"classification": classification, "ratio": round(ratio, 2)}
+    data_quality = "suspicious_volume" if ratio > 10.0 else "ok"
+    return {"classification": classification, "ratio": round(ratio, 2), "data_quality": data_quality}

--- a/claude_advisor/prompts.py
+++ b/claude_advisor/prompts.py
@@ -40,13 +40,15 @@ Classify each flagged asset into exactly one of five categories using the Diverg
 
 Apply these rules before anything else. They override any pattern-matching instinct:
 
-- If Volume >3x AND Social Heat is "stable" or "low" → MUST classify as "institutional_rebalancing". Never "irrational_panic". The absence of retail noise during heavy volume is the defining signature of institutional activity.
+- If Volume >3x AND Social Heat is "stable" or "low" → MUST classify as "institutional_rebalancing". Never "irrational_panic". The absence of retail noise during heavy volume is the defining signature of institutional activity. This rule requires CONFIRMED low heat from at least one available source. `social_heat_z: n/a` alone does not satisfy this — n/a means no data, not low heat.
 - If Volume >3x AND Social Heat is "explosive" AND tone is "bearish" → MUST classify as "irrational_panic".
 - If Volume >3x AND Social Heat is "explosive" AND tone is "bullish" → MUST classify as "bubble_forming".
 - Social Heat alone (without volume confirmation ≥ 2x) → always "ambiguous" or "no_signal". Do not manufacture a conviction call from social data alone.
 - z-scores between -1.5 and +1.5 are noise, not signal, even when volume is elevated.
 
 ## How to Weigh the Signals
+
+**IMPORTANT — Data availability vs low heat:** StockTwits has been removed. When `social_heat_z: n/a` appears, it means NO DATA, not LOW HEAT. Do NOT treat `n/a` as confirmation of "stable" or "quiet" social activity. In these cases, fall back to YouTube heat/tone as the primary social signal. If YouTube is also `n/a` or absent, default to "ambiguous" rather than inferring institutional flow.
 
 1. **Volume is the primary ingredient.** "anomalous" (>2.5x) or "extreme" (>5x) 30d-average volume is a prerequisite for any high-confidence call. Without it, even large price moves are usually noise.
 2. **Price velocity (z-score)** tells you the direction and intensity of the move relative to recent history. Dual-window confirmation (both z_30d and z_200d elevated) is a stronger signal than a single window.
@@ -66,7 +68,7 @@ Always factor in the macro header before scoring confidence:
 
 ## Special Notes
 
-- **Commodities (GC=F, SI=F, CL=F, HG=F, ZS=F, NG=F)**: naturally attract institutional volume with low retail chatter. Default toward "institutional_rebalancing" unless StockTwits heat is clearly "elevated" or "explosive". Gold and silver in particular have deep institutional markets; anomalous volume without social heat is almost always institutional.
+- **Commodities (GC=F, SI=F, CL=F, HG=F, ZS=F, NG=F)**: naturally attract institutional volume with low retail chatter. Default toward "institutional_rebalancing" unless YouTube heat is clearly "elevated" or "explosive" AND tone is non-neutral. Gold and silver in particular have deep institutional markets; anomalous volume without social heat is almost always institutional.
 - **High-beta retail-driven names (PLTR, MSTR, RKLB, ASTS, RDDT)**: these assets are structurally prone to retail-driven moves. Social heat carries more weight here than it does for large-cap stocks. "explosive" heat for PLTR/MSTR is more meaningful than for AAPL.
 - **Large-cap bellwethers (AAPL, AMZN, GOOGL)**: institutional flows dominate. Require stronger social heat divergence before classifying as retail-driven panic or bubble.
 - **Bitcoin proxies (MSTR)**: treat as a high-beta retail name. Social heat and tone are highly predictive.

--- a/collectors/market_data.py
+++ b/collectors/market_data.py
@@ -110,8 +110,13 @@ def fetch_market_data(ticker: str, lookback_days: int = 30) -> dict:
     previous_close = float(closes.iloc[-2]) if len(closes) >= 2 else current_price
     current_volume = float(volumes.iloc[-1])
 
-    # Short-window volume average (exclude today)
-    avg_volume_30d = float(volumes.iloc[-(lookback_days + 1):-1].mean())
+    # Short-window volume average (exclude today). Zero-volume days are filtered
+    # out before averaging: futures contract rolls often produce a run of zero
+    # rows in yfinance data, which would collapse the denominator and produce
+    # impossibly large multiples (e.g. GC=F 46x) the next real trading day.
+    vol_slice    = volumes.iloc[-(lookback_days + 1):-1]
+    vol_nonzero  = vol_slice[vol_slice > 0]
+    avg_volume_30d = float(vol_nonzero.mean()) if len(vol_nonzero) > 0 else float(vol_slice.mean())
 
     returns = closes.pct_change().dropna()
     returns_mean_30d,  returns_std_30d  = _returns_stats(returns, lookback_days)

--- a/delivery/email_sender.py
+++ b/delivery/email_sender.py
@@ -335,6 +335,18 @@ def _sentiment_row(sentiment: dict | None) -> str:
 
 # ── cluster alerts card ────────────────────────────────────────────────────
 
+def _data_quality_badge(data_quality: str, ratio: float) -> str:
+    """Warning banner shown when volume multiple exceeds the suspicious threshold."""
+    if data_quality != "suspicious_volume":
+        return ""
+    return (
+        f"<div style='background:#422006;border:1px solid #92400e;border-radius:4px;"
+        f"padding:6px 10px;margin-top:8px;font-size:11px;color:#fbbf24;font-weight:600;'>"
+        f"⚠ DATA QUALITY: extreme volume reading ({ratio:.1f}x) — verify before acting"
+        f"</div>"
+    )
+
+
 def _cluster_boost_badge(cluster_boost: dict) -> str:
     """Inline badge shown on individual asset cards when a cluster boost was applied."""
     sector    = cluster_boost.get("sector", "")
@@ -473,6 +485,7 @@ def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | Non
     )
 
     boost_badge = _cluster_boost_badge(cluster_boost) if cluster_boost else ""
+    dq_badge    = _data_quality_badge(v.get("data_quality", "ok"), v["ratio"])
 
     return (
         f"<div style='background:#1a1a1a;border-radius:6px;border-left:4px solid {border};"
@@ -491,6 +504,8 @@ def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | Non
         f"</tr></tbody></table>"
         # metrics
         f"<table style='border-collapse:collapse;'><tbody><tr>{metric_tds}</tr></tbody></table>"
+        # data quality warning (shown only when suspicious_volume)
+        f"{dq_badge}"
         # news + sentiment
         f"{news_html}"
         f"{sentiment_html}"

--- a/main.py
+++ b/main.py
@@ -132,6 +132,12 @@ def run_pipeline(tickers: list[str]) -> list[dict]:
             continue
 
         volume   = analyze_volume(market)
+        if volume.get("data_quality") == "suspicious_volume":
+            logger.warning(
+                "[DATA QUALITY] %s volume multiple %.1fx exceeds threshold"
+                " — consider review",
+                ticker, volume["ratio"],
+            )
         velocity = analyze_price_velocity(market)
         rsi      = analyze_rsi(market)
 

--- a/tests/test_volume_data_quality.py
+++ b/tests/test_volume_data_quality.py
@@ -1,0 +1,78 @@
+"""Tests for Fix 3: suspicious volume guard in analyze_volume.
+
+Asserts that signals with a volume multiple > 10x receive
+data_quality: "suspicious_volume", and all others receive "ok".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from analyzers.volume_analyzer import analyze_volume
+
+
+def _mkt(current: float, avg: float) -> dict:
+    return {"current_volume": current, "avg_volume_30d": avg}
+
+
+# ── happy-path ────────────────────────────────────────────────────────────────
+
+def test_normal_volume_is_ok():
+    result = analyze_volume(_mkt(1_000_000, 1_000_000))
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "normal"
+
+
+def test_elevated_volume_is_ok():
+    result = analyze_volume(_mkt(2_000_000, 1_000_000))
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "elevated"
+
+
+def test_anomalous_volume_is_ok():
+    result = analyze_volume(_mkt(3_500_000, 1_000_000))
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "anomalous"
+
+
+def test_extreme_volume_below_10x_is_ok():
+    result = analyze_volume(_mkt(9_900_000, 1_000_000))
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "extreme"
+
+
+# ── boundary ──────────────────────────────────────────────────────────────────
+
+def test_exactly_10x_is_ok():
+    """The threshold is strictly > 10x; exactly 10.0x must NOT be flagged."""
+    result = analyze_volume(_mkt(10_000_000, 1_000_000))
+    assert result["ratio"] == 10.0
+    assert result["data_quality"] == "ok"
+
+
+# ── suspicious ────────────────────────────────────────────────────────────────
+
+def test_just_above_10x_is_suspicious():
+    result = analyze_volume(_mkt(10_000_001, 1_000_000))
+    assert result["data_quality"] == "suspicious_volume"
+
+
+def test_commodity_like_spike_is_suspicious():
+    """Reproduces the GC=F / SI=F 46x pattern from May 7 production email."""
+    result = analyze_volume(_mkt(46_000_000, 1_000_000))
+    assert result["data_quality"] == "suspicious_volume"
+    assert result["classification"] == "extreme"
+
+
+def test_25x_is_suspicious():
+    result = analyze_volume(_mkt(25_000_000, 1_000_000))
+    assert result["data_quality"] == "suspicious_volume"
+
+
+# ── edge: zero baseline ───────────────────────────────────────────────────────
+
+def test_zero_baseline_returns_ok():
+    """No division by zero; falls through to the early-return path."""
+    result = analyze_volume(_mkt(1_000_000, 0))
+    assert result["data_quality"] == "ok"
+    assert result["ratio"] == 0.0

--- a/utils/token_optimizer.py
+++ b/utils/token_optimizer.py
@@ -116,7 +116,15 @@ def compress_signals(ticker: str, name: str, signals: dict) -> str:
 
     macro_flag = " ⚠ macro_extreme" if p.get("macro_extreme") else ""
 
+    dq_flag = ""
+    if v.get("data_quality") == "suspicious_volume":
+        dq_flag = (
+            f"⚠ DATA QUALITY FLAG: This ticker's volume multiple ({v['ratio']}x) exceeds normal"
+            f" range and may be a data artifact. Weight volume evidence accordingly.\n\n"
+        )
+
     return (
+        f"{dq_flag}"
         f"Asset: {ticker} ({name})\n\n"
         f"Market signals:\n"
         f"- Volume: {v['classification']} ({v['ratio']}x 30d avg)\n"


### PR DESCRIPTION
Fix 1 — Volume sanity (Option B: filter zero-volume days)
Root cause: yfinance futures data (GC=F, SI=F, HG=F) includes zero-volume
rows during contract rolls. These zeros collapse the 30-day denominator,
causing today's normal institutional volume to appear as a 16-46x spike.
Fix: exclude vol==0 days before computing avg_volume_30d in market_data.py,
falling back to the unfiltered slice only if every day was zero.

Fix 2 — System prompt n/a social heat disambiguation
• Added IMPORTANT block at top of "How to Weigh the Signals": n/a = NO DATA,
  not low heat; fall back to YouTube; default to ambiguous if both absent.
• Divergence Rule for institutional_rebalancing now requires CONFIRMED low
  heat from at least one available source (n/a alone does not satisfy it).
• Commodities special note: replaced "StockTwits heat" with "YouTube heat ...
  AND tone is non-neutral" to match current data-source reality.

Fix 3 — Suspicious volume guard
• analyze_volume() returns data_quality: "suspicious_volume" when ratio > 10x,
  "ok" otherwise.
• main.py logs [DATA QUALITY] warning for any ticker exceeding the threshold.
• token_optimizer.compress_signals() prepends a ⚠ DATA QUALITY FLAG block to
  the per-asset prompt section so the classifier can discount the reading.
• email_sender._asset_card() renders an amber warning banner below the metrics
  row when data_quality == suspicious_volume.
• New test: tests/test_volume_data_quality.py — 9 cases covering normal,
  boundary (exactly 10x), just-above, commodity-like spikes, and zero baseline.

No changes to cluster_detector, validation harness, or position_tracker.

https://claude.ai/code/session_012uYamZjoTLuHFJwVDVPYKZ