### PR TITLE
feat: position sizing, price targets, time windows, option strikes

### DIFF
--- a/analyzers/position_sizing.py
+++ b/analyzers/position_sizing.py
@@ -1,0 +1,207 @@
+"""Position sizing, price targets, time windows, and option strikes.
+
+Pure post-classification math — no API calls, no new data sources.
+All functions operate on dicts produced by the main pipeline and the
+Claude classification step.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def compute_position_size(signal: dict, macro_context: dict) -> float:
+    """Return position size as a percentage of capital.
+
+    Returns 0.0 for non-directional recommendations or confidence < 6.
+
+    signal keys used: confidence (int), recommendation (str), cluster_boost (dict|None)
+    macro_context keys: buffett_indicator (float, ratio_pct e.g. 231),
+                        fear_greed (int, 0-100 score)
+    """
+    confidence = signal.get("confidence", 0)
+
+    if confidence >= 9:
+        tier_base = 3.0
+    elif confidence >= 7:
+        tier_base = 2.0
+    elif confidence >= 6:
+        tier_base = 1.0
+    else:
+        return 0.0
+
+    rec = signal.get("recommendation", "")
+    if rec == "contrarian_buy":
+        rec_mult = 1.2
+    elif rec == "reduce_exposure":
+        rec_mult = 1.0
+    else:
+        return 0.0
+
+    cluster_mult = 1.25 if signal.get("cluster_boost") else 1.0
+
+    buffett = macro_context.get("buffett_indicator", 0)
+    fg      = macro_context.get("fear_greed", 100)
+    macro_damp = 0.7 if (buffett > 220 or fg < 40) else 1.0
+
+    return tier_base * rec_mult * cluster_mult * macro_damp
+
+
+def compute_price_targets(
+    current_price: float,
+    z_score_30d: float,
+    returns_std_30d: float,
+    recommendation: str,
+) -> dict:
+    """Return three price targets from z-score reversion math.
+
+    S = current_price * returns_std_30d  (dollar volatility)
+    M = current_price - z_score_30d * S  (implied mean reference price)
+
+    For reduce_exposure (bearish): targets at z=+1, z=0, z=-1
+    For contrarian_buy  (bullish): targets at z=-1, z=0, z=+1
+    """
+    S = current_price * returns_std_30d
+    M = current_price - z_score_30d * S
+    is_bearish = recommendation == "reduce_exposure"
+
+    if is_bearish:
+        conservative = M + S   # z = +1
+        medium       = M       # z =  0
+        aggressive   = M - S   # z = -1
+    else:
+        conservative = M - S   # z = -1
+        medium       = M       # z =  0
+        aggressive   = M + S   # z = +1
+
+    return {
+        "conservative": round(conservative, 2),
+        "medium":       round(medium,       2),
+        "aggressive":   round(aggressive,   2),
+        "is_bearish":   is_bearish,
+    }
+
+
+def compute_option_strikes(current_price: float, recommendation: str) -> dict:
+    """Return ATM, OTM 5%, OTM 10% strikes (display only, no IV or expiry logic).
+
+    Shorts (reduce_exposure): OTM strikes are below current price.
+    Longs (contrarian_buy):   OTM strikes are above current price.
+    """
+    atm      = round(current_price)
+    is_short = recommendation == "reduce_exposure"
+
+    if is_short:
+        otm_5pct  = round(current_price * 0.95)
+        otm_10pct = round(current_price * 0.90)
+    else:
+        otm_5pct  = round(current_price * 1.05)
+        otm_10pct = round(current_price * 1.10)
+
+    return {"atm": atm, "otm_5pct": otm_5pct, "otm_10pct": otm_10pct}
+
+
+def compute_time_windows(today: datetime.date | None = None) -> dict:
+    """Return d+10 checkpoint and d+30 close dates as ISO strings.
+
+    d+10 advances past weekends so the checkpoint is always a weekday.
+    d+30 is a calendar date (weekends acceptable for the close target).
+    """
+    if today is None:
+        today = datetime.date.today()
+
+    d10 = today + datetime.timedelta(days=10)
+    while d10.weekday() >= 5:   # skip Saturday (5) and Sunday (6)
+        d10 += datetime.timedelta(days=1)
+
+    d30 = today + datetime.timedelta(days=30)
+
+    return {"d10": d10.isoformat(), "d30": d30.isoformat()}
+
+
+def compute_sizing_block(
+    classified_signal: dict,
+    market_data: dict,
+    velocity_data: dict,
+    macro_context: dict,
+    today: datetime.date | None = None,
+) -> dict | None:
+    """Assemble the full sizing block for one signal.
+
+    Returns None when position_size == 0 (non-actionable signal) or when
+    required price/z-score data is missing.  Never raises — logs a warning
+    and returns None on any unexpected failure.
+
+    classified_signal: Claude output dict (confidence, recommendation, cluster_boost)
+    market_data:       r["signals"]["market"] (current_price, returns_std_30d)
+    velocity_data:     r["signals"]["velocity"] (z_score_30d)
+    macro_context:     {"buffett_indicator": float, "fear_greed": int}
+    """
+    try:
+        position_size = compute_position_size(classified_signal, macro_context)
+        if position_size == 0:
+            return None
+
+        current_price   = market_data.get("current_price")
+        z_score_30d     = velocity_data.get("z_score_30d")
+        returns_std_30d = market_data.get("returns_std_30d")
+
+        if None in (current_price, z_score_30d, returns_std_30d):
+            logger.warning(
+                "position_sizing: missing data for %s (price=%s z30=%s std=%s)",
+                classified_signal.get("ticker", "?"),
+                current_price, z_score_30d, returns_std_30d,
+            )
+            return None
+
+        recommendation = classified_signal.get("recommendation", "")
+
+        targets = compute_price_targets(
+            current_price, z_score_30d, returns_std_30d, recommendation
+        )
+        strikes = compute_option_strikes(current_price, recommendation)
+        windows = compute_time_windows(today)
+
+        return {
+            "position_size_pct": round(position_size, 2),
+            "targets":           targets,
+            "strikes":           strikes,
+            "windows":           windows,
+        }
+    except Exception as exc:
+        logger.warning(
+            "position_sizing: compute_sizing_block failed for %s: %s",
+            classified_signal.get("ticker", "?"), exc,
+        )
+        return None
+
+
+def format_sizing_text(ticker: str, sizing_block: dict) -> str:
+    """Format a sizing block as a plain-text block for paste/log output."""
+    size = sizing_block["position_size_pct"]
+    t    = sizing_block["targets"]
+    w    = sizing_block["windows"]
+    s    = sizing_block["strikes"]
+
+    is_bearish = t.get("is_bearish", False)
+    if is_bearish:
+        z_labels = ("z=+1", "z=0", "z=-1")
+    else:
+        z_labels = ("z=-1", "z=0", "z=+1")
+
+    def _px(v: float) -> str:
+        return f"${v:,.2f}"
+
+    return (
+        f"[{ticker}] \U0001f3af SIZING & TARGETS\n"
+        f"  Position size:   {size:.2f}% of capital\n"
+        f"  Targets:         conservative {_px(t['conservative'])} ({z_labels[0]})"
+        f" | medium {_px(t['medium'])} ({z_labels[1]})"
+        f" | aggressive {_px(t['aggressive'])} ({z_labels[2]})\n"
+        f"  Window:          checkpoint {w['d10']} (d+10) · close {w['d30']} (d+30)\n"
+        f"  Option strikes:  ATM ${s['atm']:,} | OTM 5% ${s['otm_5pct']:,}"
+        f" | OTM 10% ${s['otm_10pct']:,}"
+    )

--- a/delivery/email_sender.py
+++ b/delivery/email_sender.py
@@ -411,9 +411,63 @@ def _cluster_alerts_card(active_clusters: list[dict]) -> str:
     )
 
 
+# ── sizing panel ──────────────────────────────────────────────────────────
+
+def _sizing_panel(sizing_block: dict) -> str:
+    """Render the sizing + targets block as a muted monospace panel."""
+    size = sizing_block["position_size_pct"]
+    t    = sizing_block["targets"]
+    w    = sizing_block["windows"]
+    s    = sizing_block["strikes"]
+
+    is_bearish = t.get("is_bearish", False)
+    z_labels   = ("z=+1", "z=0", "z=−1") if is_bearish else ("z=−1", "z=0", "z=+1")
+
+    def _px(v: float) -> str:
+        return f"${v:,.2f}"
+
+    label_style = "color:#4b5563;"
+    value_style = "color:#9ca3af;"
+
+    def row(label: str, value: str) -> str:
+        pad = "&nbsp;" * max(0, 17 - len(label))
+        return (
+            f"<div style='margin:2px 0;font-size:11px;'>"
+            f"<span style='{label_style}'>{label}{pad}</span>"
+            f"<span style='{value_style}'>{value}</span>"
+            f"</div>"
+        )
+
+    targets_str = (
+        f"conservative {_px(t['conservative'])} ({z_labels[0]})"
+        f" &nbsp;|&nbsp; medium {_px(t['medium'])} ({z_labels[1]})"
+        f" &nbsp;|&nbsp; aggressive {_px(t['aggressive'])} ({z_labels[2]})"
+    )
+    window_str = (
+        f"checkpoint {w['d10']} (d+10) &middot; close {w['d30']} (d+30)"
+    )
+    strikes_str = (
+        f"ATM ${s['atm']:,} &nbsp;|&nbsp; OTM 5% ${s['otm_5pct']:,}"
+        f" &nbsp;|&nbsp; OTM 10% ${s['otm_10pct']:,}"
+    )
+
+    return (
+        f"<div style='background:#111827;border:1px solid #1f2937;border-radius:4px;"
+        f"padding:10px 12px;margin-top:10px;"
+        f"font-family:\"Menlo\",\"Monaco\",\"Courier New\",monospace;'>"
+        f"<div style='font-size:9px;font-weight:700;color:#374151;letter-spacing:.08em;"
+        f"text-transform:uppercase;margin-bottom:6px;'>&#127919; SIZING &amp; TARGETS</div>"
+        + row("Position size:", f"{size:.2f}% of capital")
+        + row("Targets:", targets_str)
+        + row("Window:", window_str)
+        + row("Option strikes:", strikes_str)
+        + "</div>"
+    )
+
+
 # ── asset card ─────────────────────────────────────────────────────────────
 
-def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | None = None) -> str:
+def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | None = None, sizing_block: dict | None = None) -> str:
     name = TICKER_NAMES.get(ticker, ticker)
     m = signals["market"]
     v = signals["volume"]
@@ -486,6 +540,7 @@ def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | Non
 
     boost_badge = _cluster_boost_badge(cluster_boost) if cluster_boost else ""
     dq_badge    = _data_quality_badge(v.get("data_quality", "ok"), v["ratio"])
+    sizing_html = _sizing_panel(sizing_block) if sizing_block else ""
 
     return (
         f"<div style='background:#1a1a1a;border-radius:6px;border-left:4px solid {border};"
@@ -509,6 +564,8 @@ def _asset_card(ticker: str, signals: dict, tier: str, cluster_boost: dict | Non
         # news + sentiment
         f"{news_html}"
         f"{sentiment_html}"
+        # sizing & targets (only when classified signal is actionable)
+        f"{sizing_html}"
         f"</div>"
     )
 
@@ -527,18 +584,18 @@ def build_html_email(
     active_clusters: list[dict] | None = None,
 ) -> str:
     red_items   = [
-        (r["ticker"], r["signals"], r.get("cluster_boost"))
+        (r["ticker"], r["signals"], r.get("cluster_boost"), r.get("sizing_block"))
         for r in results if get_alert_tier(r["signals"]) == "red"
     ]
     amber_items = [
-        (r["ticker"], r["signals"], r.get("cluster_boost"))
+        (r["ticker"], r["signals"], r.get("cluster_boost"), r.get("sizing_block"))
         for r in results if get_alert_tier(r["signals"]) == "amber"
     ]
-    red_tickers   = [t for t, _, _ in red_items]
-    amber_tickers = [t for t, _, _ in amber_items]
+    red_tickers   = [t for t, _, _, _ in red_items]
+    amber_tickers = [t for t, _, _, _ in amber_items]
 
-    cards = "".join(_asset_card(t, s, "red",   cb) for t, s, cb in red_items)
-    cards += "".join(_asset_card(t, s, "amber", cb) for t, s, cb in amber_items)
+    cards = "".join(_asset_card(t, s, "red",   cb, sb) for t, s, cb, sb in red_items)
+    cards += "".join(_asset_card(t, s, "amber", cb, sb) for t, s, cb, sb in amber_items)
     if not cards:
         cards = (
             "<div style='background:#1a1a1a;border-radius:6px;padding:16px;color:#64748b;"
@@ -546,6 +603,19 @@ def build_html_email(
             "No alerts today — all tickers within normal ranges."
             "</div>"
         )
+
+    # Append plain-text sizing blocks for any actionable signals
+    from analyzers.position_sizing import format_sizing_text as _fmt_sizing
+
+    sizing_lines = []
+    for r in results:
+        sb = r.get("sizing_block")
+        if sb and get_alert_tier(r["signals"]):
+            sizing_lines.append(_fmt_sizing(r["ticker"], sb))
+    sizing_addendum = (
+        "\n\n" + "─" * 72 + "\nSIZING & TARGETS (post-classification)\n" + "─" * 72 + "\n"
+        + "\n\n".join(sizing_lines)
+    ) if sizing_lines else ""
 
     paste_block = (
         f"<div style='background:#18181b;border-radius:6px;padding:20px;"
@@ -555,7 +625,7 @@ def build_html_email(
         f"<pre style='margin:0;font-size:10px;line-height:1.55;color:#d1d5db;"
         f"font-family:\"Menlo\",\"Monaco\",\"Courier New\",monospace;"
         f"white-space:pre-wrap;word-break:break-word;overflow-wrap:anywhere;'>"
-        f"{html.escape(report_text)}</pre>"
+        f"{html.escape(report_text + sizing_addendum)}</pre>"
         f"</div>"
     )
 

--- a/main.py
+++ b/main.py
@@ -327,6 +327,63 @@ def print_ticker_management_section(
         )
 
 
+def _attach_sizing_blocks(
+    results: list[dict],
+    date: dt.date,
+    buffett: dict | None,
+    fear_greed: dict | None,
+    logs_dir: str = LOGS_DIR,
+) -> None:
+    """Read classified signals for `date` and attach a sizing_block to each result.
+
+    Mutates results in-place.  Silently no-ops when the signals JSON is absent
+    (manual-paste workflow) or when any individual computation fails.
+    """
+    from analyzers.position_sizing import compute_sizing_block
+
+    signals_path = os.path.join(logs_dir, f"signals_{date.isoformat()}.json")
+    classified_signals: list[dict] = []
+    if os.path.exists(signals_path):
+        try:
+            with open(signals_path, encoding="utf-8") as fh:
+                classified_signals = json.load(fh).get("signals", [])
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("position sizing: could not load %s: %s", signals_path, exc)
+
+    if not classified_signals:
+        return
+
+    classified_by_ticker = {s["ticker"]: s for s in classified_signals}
+    macro_for_sizing = {
+        "buffett_indicator": (buffett or {}).get("ratio_pct", 0),
+        "fear_greed":        (fear_greed or {}).get("score", 100),
+    }
+
+    for r in results:
+        classified = classified_by_ticker.get(r["ticker"])
+        if not classified:
+            continue
+        if r.get("cluster_boost") and "cluster_boost" not in classified:
+            classified = dict(classified)
+            classified["cluster_boost"] = r["cluster_boost"]
+        try:
+            sizing = compute_sizing_block(
+                classified_signal=classified,
+                market_data=r["signals"]["market"],
+                velocity_data=r["signals"]["velocity"],
+                macro_context=macro_for_sizing,
+                today=date,
+            )
+            if sizing:
+                r["sizing_block"] = sizing
+                logger.info(
+                    "position sizing: %s → %.2f%% of capital",
+                    r["ticker"], sizing["position_size_pct"],
+                )
+        except Exception as exc:
+            logger.warning("position sizing: failed for %s: %s", r["ticker"], exc)
+
+
 def archive_log(report_path: str, date: dt.date, logs_dir: str = LOGS_DIR) -> str:
     """Copy the generated report into logs/ for the GitHub Action to commit back."""
     os.makedirs(logs_dir, exist_ok=True)
@@ -594,6 +651,13 @@ def main(argv: list[str]) -> int:
                 logger.info("clusters saved to %s", clusters_path)
             except OSError as exc:
                 logger.warning("cluster boost: could not save clusters (%s)", exc)
+
+    # ── Position Sizing ───────────────────────────────────────────────────────
+    # Reads classified signals (written by the Claude advisor / add_recommendations
+    # workflow) and attaches a sizing_block to each result for email rendering.
+    # Silently skipped when the signals file is absent (manual-paste workflow).
+    # _attach_sizing_blocks picks up in-memory cluster_boost already merged into results.
+    _attach_sizing_blocks(results, date, buffett, fear_greed)
 
     if send_email:
         try:

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -1,0 +1,188 @@
+"""Tests for analyzers/position_sizing.py.
+
+Ten deterministic cases covering the full sizing formula, macro dampener
+edge-cases, price-target reversion math, and option strike directions.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from analyzers.position_sizing import (
+    compute_option_strikes,
+    compute_position_size,
+    compute_price_targets,
+    compute_sizing_block,
+    compute_time_windows,
+)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+def _sig(confidence: int, rec: str, cluster: bool = False) -> dict:
+    s: dict = {"confidence": confidence, "recommendation": rec}
+    if cluster:
+        s["cluster_boost"] = {"boost_amount": 1}
+    return s
+
+
+def _macro(buffett: float = 150.0, fg: int = 60) -> dict:
+    return {"buffett_indicator": buffett, "fear_greed": fg}
+
+
+# ── test 1 ────────────────────────────────────────────────────────────────
+
+def test_confidence_below_6_returns_zero():
+    """Confidence < 6 → position size must be 0 regardless of recommendation."""
+    assert compute_position_size(_sig(5, "contrarian_buy"), _macro()) == 0.0
+    assert compute_position_size(_sig(1, "reduce_exposure"), _macro()) == 0.0
+
+
+# ── test 2 ────────────────────────────────────────────────────────────────
+
+def test_confidence_6_reduce_exposure_no_cluster_no_macro_damp():
+    """conf=6, reduce_exposure, no cluster, no dampener → 1.0 × 1.0 × 1.0 × 1.0 = 1.0%."""
+    result = compute_position_size(_sig(6, "reduce_exposure"), _macro())
+    assert result == pytest.approx(1.0)
+
+
+# ── test 3 ────────────────────────────────────────────────────────────────
+
+def test_confidence_9_contrarian_buy_cluster_no_macro_damp():
+    """conf=9, contrarian_buy, cluster boost, no dampener → 3 × 1.2 × 1.25 × 1.0 = 4.5%."""
+    result = compute_position_size(_sig(9, "contrarian_buy", cluster=True), _macro())
+    assert result == pytest.approx(4.5)
+
+
+# ── test 4 ────────────────────────────────────────────────────────────────
+
+def test_confidence_8_reduce_exposure_no_cluster_with_macro_damp():
+    """conf=8, reduce_exposure, no cluster, buffett=231 → 2 × 1.0 × 1.0 × 0.7 = 1.4%."""
+    result = compute_position_size(_sig(8, "reduce_exposure"), _macro(buffett=231))
+    assert result == pytest.approx(1.4)
+
+
+# ── test 5 ────────────────────────────────────────────────────────────────
+
+def test_macro_dampener_triggers_on_buffett_alone():
+    """Buffett > 220 alone (F&G normal at 60) → dampener fires → 0.7 multiplier."""
+    macro = _macro(buffett=221, fg=60)
+    result = compute_position_size(_sig(7, "contrarian_buy"), macro)
+    assert result == pytest.approx(2.0 * 1.2 * 1.0 * 0.7)
+
+
+# ── test 6 ────────────────────────────────────────────────────────────────
+
+def test_macro_dampener_triggers_on_fear_greed_alone():
+    """F&G < 40 alone (Buffett normal at 150) → dampener fires → 0.7 multiplier."""
+    macro = _macro(buffett=150, fg=39)
+    result = compute_position_size(_sig(7, "contrarian_buy"), macro)
+    assert result == pytest.approx(2.0 * 1.2 * 1.0 * 0.7)
+
+
+# ── test 7 ────────────────────────────────────────────────────────────────
+
+def test_macro_dampener_does_not_trigger_at_boundary():
+    """Buffett = 220 (not > 220) AND F&G = 40 (not < 40) → dampener does NOT fire."""
+    macro = _macro(buffett=220, fg=40)
+    result = compute_position_size(_sig(7, "contrarian_buy"), macro)
+    assert result == pytest.approx(2.0 * 1.2 * 1.0 * 1.0)
+
+
+# ── test 8 ────────────────────────────────────────────────────────────────
+
+def test_recommendation_wait_returns_zero():
+    """Non-directional recommendations (wait, no_action) always return 0."""
+    assert compute_position_size(_sig(9, "wait"),      _macro()) == 0.0
+    assert compute_position_size(_sig(9, "no_action"), _macro()) == 0.0
+
+
+# ── test 9 ────────────────────────────────────────────────────────────────
+
+def test_price_target_reversion_math():
+    """P=100, Z=+2, returns_std=0.05 → S=5, M=90; reduce_exposure targets: 95/90/85."""
+    targets = compute_price_targets(
+        current_price=100.0,
+        z_score_30d=2.0,
+        returns_std_30d=0.05,
+        recommendation="reduce_exposure",
+    )
+    assert targets["conservative"] == pytest.approx(95.0)  # M + S = 90 + 5
+    assert targets["medium"]       == pytest.approx(90.0)  # M     = 90
+    assert targets["aggressive"]   == pytest.approx(85.0)  # M - S = 90 - 5
+    assert targets["is_bearish"] is True
+
+
+# ── test 10 ───────────────────────────────────────────────────────────────
+
+def test_option_strikes_short_signal():
+    """Short (reduce_exposure) at $100 → ATM=$100, OTM5%=$95, OTM10%=$90."""
+    strikes = compute_option_strikes(
+        current_price=100.0,
+        recommendation="reduce_exposure",
+    )
+    assert strikes["atm"]       == 100
+    assert strikes["otm_5pct"]  == 95
+    assert strikes["otm_10pct"] == 90
+
+
+# ── extras: sanity checks for contrarian_buy direction ────────────────────
+
+def test_price_target_bullish_direction():
+    """Bullish targets are symmetric mirror of bearish: P=100, Z=-2, std=0.05."""
+    targets = compute_price_targets(
+        current_price=100.0,
+        z_score_30d=-2.0,
+        returns_std_30d=0.05,
+        recommendation="contrarian_buy",
+    )
+    # S=5, M = 100 - (-2)*5 = 110
+    assert targets["conservative"] == pytest.approx(105.0)  # M - S = 110 - 5
+    assert targets["medium"]       == pytest.approx(110.0)  # M     = 110
+    assert targets["aggressive"]   == pytest.approx(115.0)  # M + S = 110 + 5
+    assert targets["is_bearish"] is False
+
+
+def test_option_strikes_long_signal():
+    """Long (contrarian_buy) at $100 → OTM strikes above price."""
+    strikes = compute_option_strikes(100.0, "contrarian_buy")
+    assert strikes["atm"]       == 100
+    assert strikes["otm_5pct"]  == 105
+    assert strikes["otm_10pct"] == 110
+
+
+def test_compute_sizing_block_returns_none_for_low_confidence():
+    """compute_sizing_block returns None when position_size=0."""
+    classified = {"confidence": 4, "recommendation": "contrarian_buy", "ticker": "NVDA"}
+    market     = {"current_price": 100.0, "returns_std_30d": 0.02}
+    velocity   = {"z_score_30d": 1.5}
+    macro      = {"buffett_indicator": 150, "fear_greed": 60}
+    assert compute_sizing_block(classified, market, velocity, macro) is None
+
+
+def test_compute_sizing_block_full_output():
+    """compute_sizing_block returns a well-formed dict for an actionable signal."""
+    classified = {"confidence": 7, "recommendation": "contrarian_buy", "ticker": "NVDA"}
+    market     = {"current_price": 200.0, "returns_std_30d": 0.025}
+    velocity   = {"z_score_30d": -1.5}
+    macro      = {"buffett_indicator": 150, "fear_greed": 60}
+    today      = datetime.date(2026, 5, 10)
+
+    block = compute_sizing_block(classified, market, velocity, macro, today=today)
+    assert block is not None
+    assert block["position_size_pct"] == pytest.approx(2.0 * 1.2 * 1.0 * 1.0)
+    assert "targets"  in block
+    assert "strikes"  in block
+    assert "windows"  in block
+    assert block["windows"]["d10"] == "2026-05-20"  # 10 days from 2026-05-10 = 2026-05-20 (Wed)
+    assert block["windows"]["d30"] == "2026-06-09"
+
+
+def test_time_windows_skips_weekend():
+    """d+10 from a Thursday that lands on Saturday → bumped to Monday."""
+    # 2026-05-07 (Thursday) + 10 = 2026-05-17 (Sunday) → bumped to 2026-05-18 (Monday)
+    windows = compute_time_windows(datetime.date(2026, 5, 7))
+    assert windows["d10"] == "2026-05-18"
+    assert windows["d30"] == "2026-06-06"


### PR DESCRIPTION
Replaces PR #44 (which had an unresolvable merge conflict from diverged history).

## What's included

**`analyzers/position_sizing.py`** (new file)
- `compute_position_size` — tier_base × rec_mult × cluster_mult × macro_damp formula
- `compute_price_targets` — z-score reversion math (conservative/medium/aggressive)
- `compute_option_strikes` — ATM, OTM 5%, OTM 10% (direction-aware)
- `compute_time_windows` — d+10 (weekday-safe) and d+30 calendar dates
- `compute_sizing_block` — assembles all of the above; returns None for non-actionable signals
- `format_sizing_text` — plain-text formatter for paste block addendum

**`tests/test_position_sizing.py`** (new file)
- 15 deterministic tests covering: confidence tiers, macro dampener boundary conditions (buffett=220/fg=40 does NOT fire; buffett=221 OR fg=39 DOES), z-score reversion math, option strike direction, weekend skip logic

**`main.py`** (modified)
- `_attach_sizing_blocks()` wired after the cluster boost block; propagates in-memory `cluster_boost` so `cluster_mult=1.25` applies correctly
- `send_report()` call receives `active_clusters` kwarg

**`delivery/email_sender.py`** (modified)
- `_sizing_panel()` — dark monospace HTML panel rendered inside each asset card
- `_asset_card` accepts both `cluster_boost` and `sizing_block`
- `build_html_email` uses 4-tuples `(ticker, signals, cluster_boost, sizing_block)` throughout
- Sizing addendum appended to the plain-text paste block

## Sizing formula

```
position_size = tier_base × rec_mult × cluster_mult × macro_damp

tier_base:   conf ≥ 9 → 3.0 | conf ≥ 7 → 2.0 | conf ≥ 6 → 1.0 | else 0
rec_mult:    contrarian_buy → 1.2 | reduce_exposure → 1.0 | else 0
cluster_mult: cluster_boost present → 1.25 | else 1.0
macro_damp:  buffett > 220 OR fear_greed < 40 → 0.7 | else 1.0
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019qwS7865mTbFaGg9p4fDRX)_