### PR TITLE
feat: two-tier email — digest + GitHub Pages full report

### DIFF
--- a/.github/workflows/daily_radar.yml
+++ b/.github/workflows/daily_radar.yml
@@ -82,6 +82,10 @@ jobs:
             git config user.name  "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add logs/
+            # Stage GitHub Pages report if written (docs/ may not exist on closed days)
+            if [ -d docs ]; then
+              git add docs/
+            fi
             if git diff --cached --quiet; then
               echo "no new logs to commit"
             else

--- a/delivery/digest_builder.py
+++ b/delivery/digest_builder.py
@@ -1,0 +1,259 @@
+"""Build the Tier-1 digest email — mobile-first, one-screen summary.
+
+Sends only the essential daily briefing with a link to the full report on
+GitHub Pages. The full HTML email (asset cards, paste block, etc.) is
+written to docs/reports/YYYY-MM-DD.html by pages_publisher.py instead.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import html as html_lib
+
+from output.document_builder import get_alert_tier
+
+PAGES_BASE_URL = "https://nafomatos.github.io/Assistente-virtual"
+
+
+def _truncate(text: str, n: int) -> str:
+    text = (text or "").strip()
+    return text if len(text) <= n else text[:n - 1].rstrip() + "…"
+
+
+def _fg_color(score: int) -> str:
+    if score < 30:
+        return "#ef4444"
+    if score < 45:
+        return "#f97316"
+    if score < 55:
+        return "#94a3b8"
+    if score < 70:
+        return "#4ade80"
+    return "#22c55e"
+
+
+def _rec_label(rec: str) -> tuple[str, str]:
+    """Return (display text, badge background color)."""
+    if rec == "contrarian_buy":
+        return "BUY ↑", "#16a34a"
+    if rec == "reduce_exposure":
+        return "REDUCE ↓", "#dc2626"
+    return rec.upper(), "#475569"
+
+
+def build_digest_subject(n_actionable: int, date: dt.date) -> str:
+    return f"[Radar] {n_actionable} actionable · {date.strftime('%d %b %Y')}"
+
+
+def build_digest_html(
+    results: list[dict],
+    date: dt.date,
+    fear_greed: dict | None,
+    vix_structure: dict | None,
+    buffett: dict | None,
+    open_positions: list[dict] | None = None,
+    classified_signals: list[dict] | None = None,
+    active_clusters: list[dict] | None = None,
+) -> str:
+    """Build mobile-first digest HTML (~1 phone screen, <500 words)."""
+    classified_signals = classified_signals or []
+    active_clusters    = active_clusters or []
+    open_positions     = open_positions or []
+
+    sizing_by_ticker = {
+        r["ticker"]: r["sizing_block"]
+        for r in results
+        if r.get("sizing_block")
+    }
+
+    actionable = [
+        s for s in classified_signals
+        if s.get("recommendation") in ("contrarian_buy", "reduce_exposure")
+    ]
+
+    red_count   = sum(1 for r in results if get_alert_tier(r["signals"]) == "red")
+    amber_count = sum(1 for r in results if get_alert_tier(r["signals"]) == "amber")
+    report_url  = f"{PAGES_BASE_URL}/reports/{date.isoformat()}.html"
+
+    # ── Macro ──────────────────────────────────────────────────────────────
+    fg_score  = (fear_greed or {}).get("score")
+    fg_label  = (fear_greed or {}).get("label", "")
+    buf_pct   = (buffett or {}).get("ratio_pct")
+    buf_cls   = (buffett or {}).get("classification", "")
+    vix_val   = (vix_structure or {}).get("vix")
+    vix_inv   = (vix_structure or {}).get("vix_inverted", False)
+
+    macro_parts = []
+    if fg_score is not None:
+        color = _fg_color(fg_score)
+        macro_parts.append(
+            f"F&amp;G&nbsp;<span style='color:{color};font-weight:700;'>{fg_score}</span>"
+            f"<span style='color:#64748b;'>&nbsp;{html_lib.escape(fg_label)}</span>"
+        )
+    if buf_pct is not None:
+        macro_parts.append(
+            f"Buffett&nbsp;<span style='color:#94a3b8;font-weight:600;'>{buf_pct:.0f}%</span>"
+            f"<span style='color:#475569;'>&nbsp;{html_lib.escape(buf_cls)}</span>"
+        )
+    if vix_val is not None:
+        vix_color = "#ef4444" if vix_inv else "#94a3b8"
+        vix_state = "⚠ Backwardation" if vix_inv else "Normal"
+        macro_parts.append(
+            f"VIX&nbsp;<span style='color:{vix_color};'>{vix_val:.1f}&nbsp;—&nbsp;{vix_state}</span>"
+        )
+
+    macro_html = ""
+    if macro_parts:
+        macro_html = (
+            f"<div style='background:#1e1e1e;border-radius:6px;padding:12px 16px;"
+            f"margin-bottom:14px;font-size:12px;line-height:1.9;'>"
+            f"<div style='font-size:9px;font-weight:700;color:#475569;letter-spacing:.08em;"
+            f"text-transform:uppercase;margin-bottom:6px;'>MACRO</div>"
+            + "&nbsp;&nbsp;·&nbsp;&nbsp;".join(macro_parts)
+            + "</div>"
+        )
+
+    # ── Coverage ───────────────────────────────────────────────────────────
+    coverage_html = (
+        f"<div style='font-size:12px;color:#64748b;margin-bottom:14px;'>"
+        f"<span style='color:#ef4444;font-weight:700;'>{red_count} RED</span>"
+        f"&nbsp;&nbsp;"
+        f"<span style='color:#f97316;font-weight:700;'>{amber_count} AMBER</span>"
+        f"&nbsp;&nbsp;·&nbsp;&nbsp;"
+        f"<span style='color:#475569;'>{len(results)} tickers</span>"
+        f"</div>"
+    )
+
+    # ── Portfolio ──────────────────────────────────────────────────────────
+    positions_html = ""
+    if open_positions:
+        sorted_pos = sorted(open_positions, key=lambda p: p.get("pnl_pct", 0))
+        worst = sorted_pos[0]
+        best  = sorted_pos[-1]
+        positions_html = (
+            f"<div style='background:#1e1e1e;border-radius:6px;padding:12px 16px;"
+            f"margin-bottom:14px;font-size:12px;'>"
+            f"<div style='font-size:9px;font-weight:700;color:#475569;letter-spacing:.08em;"
+            f"text-transform:uppercase;margin-bottom:6px;'>PORTFOLIO</div>"
+            f"<span style='color:#64748b;'>{len(open_positions)} open</span>"
+            f"&nbsp;&nbsp;·&nbsp;&nbsp;"
+            f"Best&nbsp;<span style='font-weight:600;'>{html_lib.escape(best['ticker'])}</span>"
+            f"&nbsp;<span style='color:#4ade80;'>{best.get('pnl_pct', 0):+.1f}%</span>"
+            f"&nbsp;&nbsp;·&nbsp;&nbsp;"
+            f"Worst&nbsp;<span style='font-weight:600;'>{html_lib.escape(worst['ticker'])}</span>"
+            f"&nbsp;<span style='color:#ef4444;'>{worst.get('pnl_pct', 0):+.1f}%</span>"
+            f"</div>"
+        )
+
+    # ── Actionable signals ─────────────────────────────────────────────────
+    if actionable:
+        rows = ""
+        for sig in actionable:
+            ticker = sig["ticker"]
+            rec    = sig.get("recommendation", "")
+            conf   = sig.get("confidence", 0)
+            reason = _truncate(sig.get("reasoning", ""), 100)
+            label, badge_color = _rec_label(rec)
+            sb       = sizing_by_ticker.get(ticker)
+            size_str = f"{sb['position_size_pct']:.1f}%" if sb else "n/a"
+            d10_str  = sb["windows"]["d10"] if sb else "—"
+            rows += (
+                f"<div style='border-top:1px solid #27272a;padding:10px 0;'>"
+                f"<div style='display:flex;justify-content:space-between;align-items:center;"
+                f"margin-bottom:5px;'>"
+                f"<span style='font-weight:700;font-size:15px;color:#f1f5f9;'>"
+                f"{html_lib.escape(ticker)}</span>"
+                f"<span style='background:{badge_color};color:#fff;font-size:10px;"
+                f"font-weight:700;padding:2px 7px;border-radius:3px;'>{label}</span>"
+                f"</div>"
+                f"<div style='font-size:11px;color:#64748b;margin-bottom:4px;'>"
+                f"Alloc&nbsp;<span style='color:#f1f5f9;font-weight:600;'>{html_lib.escape(size_str)}</span>"
+                f"&nbsp;&nbsp;d+10&nbsp;<span style='color:#94a3b8;'>{html_lib.escape(d10_str)}</span>"
+                f"&nbsp;&nbsp;conf&nbsp;<span style='color:#94a3b8;'>{conf}/10</span>"
+                f"</div>"
+                f"<div style='font-size:11px;color:#94a3b8;font-style:italic;'>"
+                f"{html_lib.escape(reason)}</div>"
+                f"</div>"
+            )
+        actionable_html = (
+            f"<div style='background:#1a1a1a;border-radius:6px;"
+            f"padding:12px 16px;margin-bottom:14px;'>"
+            f"<div style='font-size:9px;font-weight:700;color:#475569;letter-spacing:.08em;"
+            f"text-transform:uppercase;margin-bottom:4px;'>ACTIONABLE SIGNALS</div>"
+            f"{rows}"
+            f"</div>"
+        )
+    else:
+        actionable_html = (
+            f"<div style='background:#1a1a1a;border-radius:6px;padding:14px 16px;"
+            f"margin-bottom:14px;font-size:13px;color:#64748b;font-style:italic;'>"
+            f"No actionable signals today — monitoring continues."
+            f"</div>"
+        )
+
+    # ── Cluster alerts ─────────────────────────────────────────────────────
+    cluster_html = ""
+    if active_clusters:
+        rows = ""
+        for cl in active_clusters:
+            sector    = html_lib.escape(cl.get("sector", "?"))
+            direction = html_lib.escape(cl.get("direction_group", "?"))
+            count     = cl.get("count", 0)
+            tickers_s = html_lib.escape(", ".join(cl.get("tickers", [])))
+            rows += (
+                f"<div style='font-size:12px;padding:5px 0;border-top:1px solid #1e3a5f;'>"
+                f"<span style='color:#60a5fa;font-weight:700;'>{sector}</span>"
+                f"&nbsp;—&nbsp;"
+                f"<span style='color:#94a3b8;'>{direction}</span>"
+                f"&nbsp;<span style='color:#475569;'>({count}: {tickers_s})</span>"
+                f"</div>"
+            )
+        cluster_html = (
+            f"<div style='background:#0f1f35;border:1px solid #1e3a5f;border-radius:6px;"
+            f"padding:12px 16px;margin-bottom:14px;'>"
+            f"<div style='font-size:9px;font-weight:700;color:#3b82f6;letter-spacing:.08em;"
+            f"text-transform:uppercase;margin-bottom:4px;'>CLUSTER ALERTS</div>"
+            f"{rows}"
+            f"</div>"
+        )
+
+    # ── Full-report CTA ────────────────────────────────────────────────────
+    link_html = (
+        f"<div style='text-align:center;margin-top:20px;'>"
+        f"<a href='{html_lib.escape(report_url)}'"
+        f" style='display:inline-block;background:#1e40af;color:#fff;font-size:13px;"
+        f"font-weight:600;padding:11px 26px;border-radius:6px;text-decoration:none;'>"
+        f"View Full Report &rarr;</a>"
+        f"<div style='margin-top:8px;font-size:10px;color:#374151;'>"
+        f"{html_lib.escape(report_url)}</div>"
+        f"</div>"
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body style="margin:0;padding:0;background:#0f0f0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#f1f5f9;">
+<div style="max-width:480px;margin:0 auto;padding:20px 16px;">
+
+  <div style="margin-bottom:16px;">
+    <div style="font-size:9px;font-weight:700;color:#475569;letter-spacing:.1em;text-transform:uppercase;margin-bottom:4px;">Artificial Price Radar</div>
+    <div style="font-size:20px;font-weight:700;color:#f1f5f9;">{len(actionable)} actionable &mdash; {date.strftime('%d %b %Y')}</div>
+  </div>
+
+  {macro_html}
+  {coverage_html}
+  {positions_html}
+  {actionable_html}
+  {cluster_html}
+  {link_html}
+
+  <div style="margin-top:24px;font-size:10px;color:#374151;text-align:center;">
+    Generated {date.isoformat()} &middot; Artificial Price Radar
+  </div>
+
+</div>
+</body>
+</html>"""

--- a/delivery/email_sender.py
+++ b/delivery/email_sender.py
@@ -978,15 +978,18 @@ def send_report(
     open_positions: list[dict] | None = None,
     closed_stats: dict | None = None,
     active_clusters: list[dict] | None = None,
+    classified_signals: list[dict] | None = None,
 ) -> None:
-    """Send the daily report as a multipart email (HTML + plain-text fallback).
+    """Send the Tier-1 digest email (mobile-first, one-screen summary).
 
-    Pass `results`, `fear_greed`, `vix_structure`, and `buffett` to enable
-    the HTML briefing section. Without them the email is plain-text only.
-    Pass `open_positions` and `closed_stats` to include the ACTIVE POSITIONS section.
-    Raises FileNotFoundError if the report file is missing, EmailConfigError
-    if SMTP credentials are absent.
+    The full HTML report is published separately to GitHub Pages by
+    pages_publisher.publish_report() before this function is called.
+
+    Raises FileNotFoundError if the .txt report file is missing,
+    EmailConfigError if SMTP credentials are absent.
     """
+    from delivery.digest_builder import build_digest_html, build_digest_subject
+
     date = date or dt.date.today()
     path = report_path or os.path.join(output_dir, f"daily_report_{date.isoformat()}.txt")
 
@@ -998,27 +1001,32 @@ def send_report(
 
     sender, password, recipient = _load_config()
 
+    n_actionable = sum(
+        1 for s in (classified_signals or [])
+        if s.get("recommendation") in ("contrarian_buy", "reduce_exposure")
+    )
+    subject = build_digest_subject(n_actionable, date)
+
     msg = EmailMessage()
-    msg["Subject"] = f"[Radar] Price Signals — {date.strftime('%d %b %Y')}"
+    msg["Subject"] = subject
     msg["From"]    = sender
     msg["To"]      = recipient
     msg.set_content(body)
 
     if results is not None:
-        html_body = build_html_email(
+        digest_html = build_digest_html(
             results=results,
             date=date,
             fear_greed=fear_greed,
             vix_structure=vix_structure,
             buffett=buffett,
-            report_text=body,
             open_positions=open_positions,
-            closed_stats=closed_stats,
+            classified_signals=classified_signals,
             active_clusters=active_clusters,
         )
-        msg.add_alternative(html_body, subtype="html")
+        msg.add_alternative(digest_html, subtype="html")
 
-    logger.info(f"sending {path} to {recipient} via {SMTP_HOST}:{SMTP_PORT}")
+    logger.info("sending digest to %s via %s:%d", recipient, SMTP_HOST, SMTP_PORT)
     with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as smtp:
         smtp.ehlo()
         smtp.starttls()

--- a/delivery/pages_publisher.py
+++ b/delivery/pages_publisher.py
@@ -1,0 +1,144 @@
+"""Publish daily full-report HTML to docs/ for GitHub Pages.
+
+Writes:
+  docs/reports/YYYY-MM-DD.html  — full email HTML (reuses build_html_email)
+  docs/index.html               — newest-first index, last MAX_DAYS days
+
+GitHub Pages must be configured to serve from /docs on the main branch
+(Settings → Pages → Source: Deploy from a branch → main /docs).
+The public URL base is https://nafomatos.github.io/Assistente-virtual.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import html as html_lib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+PAGES_BASE_URL = "https://nafomatos.github.io/Assistente-virtual"
+REPORTS_SUBDIR = "reports"
+MAX_DAYS = 90
+
+
+def publish_report(
+    date: dt.date,
+    results: list[dict],
+    fear_greed: dict | None,
+    vix_structure: dict | None,
+    buffett: dict | None,
+    report_text: str,
+    open_positions: list[dict] | None = None,
+    closed_stats: dict | None = None,
+    active_clusters: list[dict] | None = None,
+    docs_dir: str = "docs",
+) -> str:
+    """Write the full-report HTML to docs/reports/ and refresh docs/index.html.
+
+    Returns the public URL of the published report.
+    Never raises — logs warnings on any failure.
+    """
+    from delivery.email_sender import build_html_email
+
+    reports_dir = os.path.join(docs_dir, REPORTS_SUBDIR)
+    os.makedirs(reports_dir, exist_ok=True)
+
+    report_filename = f"{date.isoformat()}.html"
+    report_path     = os.path.join(reports_dir, report_filename)
+
+    try:
+        full_html = build_html_email(
+            results=results,
+            date=date,
+            fear_greed=fear_greed,
+            vix_structure=vix_structure,
+            buffett=buffett,
+            report_text=report_text,
+            open_positions=open_positions,
+            closed_stats=closed_stats,
+            active_clusters=active_clusters,
+        )
+        with open(report_path, "w", encoding="utf-8") as fh:
+            fh.write(full_html)
+        logger.info("pages_publisher: wrote %s", report_path)
+    except Exception as exc:
+        logger.warning("pages_publisher: failed to write report HTML — %s", exc)
+
+    try:
+        _rebuild_index(docs_dir, reports_dir)
+    except Exception as exc:
+        logger.warning("pages_publisher: failed to rebuild index — %s", exc)
+
+    return f"{PAGES_BASE_URL}/{REPORTS_SUBDIR}/{report_filename}"
+
+
+def _rebuild_index(docs_dir: str, reports_dir: str) -> None:
+    """Rewrite docs/index.html with a newest-first list of the last MAX_DAYS reports."""
+    cutoff = dt.date.today() - dt.timedelta(days=MAX_DAYS)
+
+    entries: list[tuple[dt.date, str]] = []
+    try:
+        for name in os.listdir(reports_dir):
+            if not name.endswith(".html"):
+                continue
+            stem = name[:-5]
+            try:
+                d = dt.date.fromisoformat(stem)
+            except ValueError:
+                continue
+            if d >= cutoff:
+                entries.append((d, name))
+    except OSError:
+        pass
+
+    entries.sort(reverse=True)
+
+    if entries:
+        rows = "".join(
+            f"<li style='padding:8px 0;border-bottom:1px solid #27272a;'>"
+            f"<a href='{REPORTS_SUBDIR}/{html_lib.escape(fname)}'"
+            f" style='color:#60a5fa;text-decoration:none;font-size:14px;'>"
+            f"{d.strftime('%A, %d %b %Y')}</a>"
+            f"</li>"
+            for d, fname in entries
+        )
+    else:
+        rows = (
+            "<li style='color:#64748b;font-size:13px;padding:8px 0;'>"
+            "No reports in the last 90 days.</li>"
+        )
+
+    index_html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Artificial Price Radar — Reports</title>
+</head>
+<body style="margin:0;padding:0;background:#0f0f0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#f1f5f9;">
+<div style="max-width:600px;margin:0 auto;padding:32px 16px;">
+
+  <div style="margin-bottom:24px;">
+    <div style="font-size:10px;font-weight:700;color:#475569;letter-spacing:.1em;text-transform:uppercase;margin-bottom:6px;">Artificial Price Radar</div>
+    <div style="font-size:24px;font-weight:700;">Daily Reports</div>
+    <div style="font-size:13px;color:#64748b;margin-top:4px;">Last {MAX_DAYS} days</div>
+  </div>
+
+  <ul style="list-style:none;padding:0;margin:0;">
+    {rows}
+  </ul>
+
+  <div style="margin-top:28px;font-size:11px;color:#374151;">
+    Artificial Price Radar &middot; Auto-generated daily
+  </div>
+
+</div>
+</body>
+</html>"""
+
+    index_path = os.path.join(docs_dir, "index.html")
+    with open(index_path, "w", encoding="utf-8") as fh:
+        fh.write(index_html)
+    logger.info("pages_publisher: updated %s (%d entries)", index_path, len(entries))

--- a/main.py
+++ b/main.py
@@ -592,7 +592,7 @@ def main(argv: list[str]) -> int:
     from claude_advisor.classifier import classify_signals as _classify_signals
     with open(path, "r", encoding="utf-8") as _rf:
         _report_text = _rf.read()
-    _classify_signals(_report_text, date=date)
+    _classified_signals = _classify_signals(_report_text, date=date)
 
     # ── Cluster Signal Booster ────────────────────────────────────────────────
     # Reads historical logs/signals_YYYYMMDD.json files (written by this block
@@ -666,6 +666,24 @@ def main(argv: list[str]) -> int:
     # _attach_sizing_blocks picks up in-memory cluster_boost already merged into results.
     _attach_sizing_blocks(results, date, buffett, fear_greed)
 
+    # ── GitHub Pages — full report ────────────────────────────────────────────
+    # Publish the complete HTML email to docs/reports/YYYY-MM-DD.html so the
+    # digest email can link to it.  Runs after sizing is attached so the full
+    # report includes SIZING & TARGETS panels.  Never raises.
+    from delivery.pages_publisher import publish_report as _publish_report
+    _pages_url = _publish_report(
+        date=date,
+        results=results,
+        fear_greed=fear_greed,
+        vix_structure=vix_structure,
+        buffett=buffett,
+        report_text=_report_text,
+        open_positions=open_positions,
+        closed_stats=closed_stats,
+        active_clusters=active_clusters,
+    )
+    logger.info("pages_publisher: full report at %s", _pages_url)
+
     if send_email:
         try:
             send_report(
@@ -678,6 +696,7 @@ def main(argv: list[str]) -> int:
                 open_positions=open_positions,
                 closed_stats=closed_stats,
                 active_clusters=active_clusters,
+                classified_signals=_classified_signals,
             )
             print("Email sent.")
         except EmailConfigError as e:


### PR DESCRIPTION
## Summary

- **Tier 1 email** (`delivery/digest_builder.py`): `send_report()` now sends a mobile-first digest (~1 phone screen, <500 words) with actionable signals (contrarian_buy / reduce_exposure only), macro snapshot (F&G · Buffett · VIX), cluster alerts, portfolio P&L summary, and a **View Full Report →** CTA button linking to GitHub Pages.
- **Tier 2 full report** (`delivery/pages_publisher.py`): `publish_report()` writes `docs/reports/YYYY-MM-DD.html` (full asset-card HTML, reusing the existing `build_html_email`) and refreshes `docs/index.html` (newest-first list, last 90 days). Runs after sizing blocks are attached so the full report includes SIZING & TARGETS panels.
- **Subject line** changes from `[Radar] Price Signals — DD Mon YYYY` → `[Radar] N actionable · DD Mon YYYY`.
- **Pipeline order** preserved: classify → size → publish (Pages) → email (digest).
- **Workflow** (`daily_radar.yml`): Archive step now also stages `docs/` so the published reports are committed back to main alongside the logs.

## Files changed

| File | Change |
|------|--------|
| `delivery/digest_builder.py` | **new** — `build_digest_html()`, `build_digest_subject()` |
| `delivery/pages_publisher.py` | **new** — `publish_report()`, `_rebuild_index()` |
| `docs/.nojekyll` | **new** — prevents Jekyll from stripping HTML assets |
| `docs/reports/` | **new** — placeholder directory for GitHub Pages reports |
| `delivery/email_sender.py` | `send_report()` uses digest builder; new `classified_signals` param |
| `main.py` | captures `_classified_signals` return, calls `_publish_report()`, passes `classified_signals` to `send_report()` |
| `.github/workflows/daily_radar.yml` | `git add docs/` in Archive step |

## Constraints respected

- Zero changes to cluster detector, position tracker, classifier, or sizing logic.
- No change to Anthropic API call frequency or cost.
- Full HTML email styling is preserved (reused as-is for the Pages report).

## Test plan

- [ ] All 15 existing tests pass (`pytest tests/test_tier_suppression.py tests/test_classifier.py`)
- [ ] After merge, enable GitHub Pages: **Settings → Pages → Source: Deploy from a branch → `main` `/docs` → Save**
- [ ] On next pipeline run: check `docs/reports/YYYY-MM-DD.html` is committed; confirm digest email arrives with subject `[Radar] N actionable · DD Mon YYYY` and the CTA links to the correct GitHub Pages URL
- [ ] Verify `docs/index.html` lists today's report as the first entry

## GitHub Pages — one-time setup (after merge)

```
Repository → Settings → Pages
  Source: Deploy from a branch
  Branch: main
  Folder: /docs
  → Save
```

Public URL base: `https://nafomatos.github.io/Assistente-virtual/`
Index page: `https://nafomatos.github.io/Assistente-virtual/`
Daily reports: `https://nafomatos.github.io/Assistente-virtual/reports/YYYY-MM-DD.html`

https://claude.ai/code/session_01QFKRYTVe7ocBYwooX5UZ8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFKRYTVe7ocBYwooX5UZ8f)_