### PR TITLE
fix: harden bubble-signal pipeline — single signal flow, gate consistency, parser robustness

### DIFF
--- a/claude_advisor/classifier.py
+++ b/claude_advisor/classifier.py
@@ -28,10 +28,15 @@ import logging
 import os
 import re
 
+from config import (
+    CLAUDE_MAX_TOKENS_DAILY,
+    CLAUDE_TEMPERATURE,
+    MODEL_FALLBACK,
+    MODEL_PRIMARY,
+)
+
 logger = logging.getLogger(__name__)
 
-_MODEL = "claude-opus-4-7"     # matches MODEL_PRIMARY in config
-_MAX_TOKENS = 2048
 _LOGS_DIR = "logs"
 
 
@@ -42,13 +47,20 @@ def _parse_json_section(text: str) -> list[dict]:
     - Bare array after the JSON_OUTPUT: label
     - Markdown fences around the array
     - Leading/trailing whitespace
+    - A response that is just the bare array with no JSON_OUTPUT label
+      (the model occasionally follows the report's closing instruction
+      instead of the two-section contract)
     """
-    # Find JSON_OUTPUT section
+    # Find JSON_OUTPUT section; fall back to scanning the whole response
+    # for a bare array when the label is absent.
     match = re.search(r"JSON_OUTPUT\s*:\s*", text, re.IGNORECASE)
-    if not match:
+    if match:
+        tail = text[match.end():].strip()
+    elif "[" in text:
+        logger.info("JSON_OUTPUT label missing — falling back to bare-array parse")
+        tail = text.strip()
+    else:
         raise ValueError("JSON_OUTPUT section not found in response")
-
-    tail = text[match.end():].strip()
 
     # Strip optional markdown fences
     if tail.startswith("```"):
@@ -102,21 +114,29 @@ def classify_signals(
         logger.warning("anthropic package not installed — skipping automated classification")
         return []
 
-    try:
-        client = anthropic.Anthropic(api_key=api_key)
-        response = client.messages.create(
-            model=_MODEL,
-            max_tokens=_MAX_TOKENS,
-            messages=[{"role": "user", "content": report_text}],
-        )
-        raw = response.content[0].text
-        logger.info(
-            "automated classification: input=%d output=%d tokens",
-            response.usage.input_tokens,
-            response.usage.output_tokens,
-        )
-    except Exception as exc:
-        logger.warning("automated classification: API call failed — %s", exc)
+    client = anthropic.Anthropic(api_key=api_key)
+    raw = None
+    for model in (MODEL_PRIMARY, MODEL_FALLBACK):
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=CLAUDE_MAX_TOKENS_DAILY,
+                temperature=CLAUDE_TEMPERATURE,
+                messages=[{"role": "user", "content": report_text}],
+            )
+            raw = response.content[0].text
+            logger.info(
+                "automated classification: model=%s input=%d output=%d tokens",
+                model,
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+            )
+            break
+        except Exception as exc:
+            logger.warning(
+                "automated classification: API call failed on %s — %s", model, exc
+            )
+    if raw is None:
         return []
 
     try:

--- a/claude_advisor/prompts.py
+++ b/claude_advisor/prompts.py
@@ -3,15 +3,32 @@
 The SYSTEM_PROMPT is sent with `cache_control: {"type": "ephemeral"}`
 on every call so Anthropic's prompt caching can reuse it across
 the day's per-ticker requests.
+
+All gate thresholds are interpolated from claude_advisor.signal_gates so the
+prompt can never drift from the code-enforced values. The result is still a
+static string per deploy, so prompt caching is unaffected.
 """
 
-SYSTEM_PROMPT = """You are a Senior Quantitative Analyst specializing in market microstructure and behavioral finance. Your task is to analyze flagged assets to distinguish between institutional flows and retail irrationality.
+from claude_advisor.signal_gates import (
+    AI_HW_BUFFETT_THRESHOLD,
+    AI_HW_Z200_THRESHOLD,
+    MACRO_BUBBLE_CONF_CAP,
+    MACRO_FEAR_CAP_THRESHOLD,
+    MIN_LONG_CONFIDENCE,
+    MIN_SHORT_CONFIDENCE,
+    SHORT_EXT_MIN_INDEX,
+    SHORT_EXT_MIN_SINGLE,
+    SHORT_SUSTAINED_MIN,
+    SHORT_VOL_DIST_MIN,
+)
+
+SYSTEM_PROMPT = f"""You are a Senior Quantitative Analyst specializing in market microstructure and behavioral finance. Your task is to analyze flagged assets to distinguish between institutional flows and retail irrationality.
 
 ## Core Objective
 
 Classify each flagged asset into exactly one of five categories using the Divergence Principle — the relationship between Volume, Social Heat, and Price Velocity is the key signal:
 
-- **irrational_panic** → recommendation: contrarian_buy (only when confidence ≥ 7)
+- **irrational_panic** → recommendation: contrarian_buy (only when confidence ≥ {MIN_LONG_CONFIDENCE})
   Logic: Volume >3x AND Social Heat "explosive" AND z-score <-1.5 AND tone "bearish"
   Thesis: Retail is capitulating. Price is being pushed below fair value by emotion.
 
@@ -44,10 +61,10 @@ Apply these rules before anything else. They override any pattern-matching insti
 
 These rules apply ONLY to SHORT calls (bubble_forming → reduce_exposure). They do NOT apply to longs (irrational_panic → contrarian_buy). The V1 retrospective proved every losing AI-hardware short was entered into institutional accumulation; these gates exist to stop that. They are enforced in code after you respond, so a violation will be silently overridden — apply them yourself so your reasoning matches the outcome:
 
-- **MANDATORY SHORT GATE (volume distribution):** bubble_forming requires `Vol distribution (down÷up) > 1.0` (down-day volume exceeds up-day volume = real distribution). If vol_dist ≤ 1.0, the move is accumulation/buying pressure, not euphoria — classify **institutional_rebalancing → wait** instead, regardless of social heat or z-score.
-- **SUSTAINED-EXTENSION GATE:** bubble_forming also requires `Ext vs 200d MA > +60%` (single name; > +40% for a broad index/ETF) AND `Sustained ≥ 30/60d`. A high z-score on a fresh breakout from below the 200d MA (e.g. Sustained 0/60, Ext < +30%) is NOT a sustained bubble — classify **institutional_rebalancing → wait**.
-- **AI-HARDWARE-IN-BULL RULE:** for semiconductor / AI-hardware names, if Buffett Indicator > 200% AND |z200| ≥ 2 AND vol_dist < 1.0 → the volume is institutional AI-capex demand, not retail euphoria. Force **institutional_rebalancing → wait**.
-- **MACRO FEAR CAP:** when Fear & Greed < 35, any surviving bubble_forming call has its confidence capped at 5 (below the actionable short threshold of 6). In a fear regime bubble shorts have no edge — keep them as observations, not trades. (irrational_panic is UNCAPPED in fear regimes — that is exactly when contrarian longs work.)
+- **MANDATORY SHORT GATE (volume distribution):** bubble_forming requires `Vol distribution (down÷up) > {SHORT_VOL_DIST_MIN:.1f}` (down-day volume exceeds up-day volume = real distribution). If vol_dist ≤ {SHORT_VOL_DIST_MIN:.1f}, the move is accumulation/buying pressure, not euphoria — classify **institutional_rebalancing → wait** instead, regardless of social heat or z-score.
+- **SUSTAINED-EXTENSION GATE:** bubble_forming also requires `Ext vs 200d MA > +{SHORT_EXT_MIN_SINGLE:.0%}` (single name; > +{SHORT_EXT_MIN_INDEX:.0%} for a broad index/ETF) AND `Sustained ≥ {SHORT_SUSTAINED_MIN}/60d`. A high z-score on a fresh breakout from below the 200d MA (e.g. Sustained 0/60, Ext < +30%) is NOT a sustained bubble — classify **institutional_rebalancing → wait**.
+- **AI-HARDWARE-IN-BULL RULE:** for semiconductor / AI-hardware names, if Buffett Indicator > {AI_HW_BUFFETT_THRESHOLD:.0f}% AND z200 ≥ +{AI_HW_Z200_THRESHOLD:.0f} AND vol_dist ≤ {SHORT_VOL_DIST_MIN:.1f} → the volume is institutional AI-capex demand, not retail euphoria. Force **institutional_rebalancing → wait**.
+- **MACRO FEAR CAP:** when Fear & Greed < {MACRO_FEAR_CAP_THRESHOLD}, any surviving bubble_forming call has its confidence capped at {MACRO_BUBBLE_CONF_CAP} (below the actionable short threshold of {MIN_SHORT_CONFIDENCE}). In a fear regime bubble shorts have no edge — keep them as observations, not trades. (irrational_panic is UNCAPPED in fear regimes — that is exactly when contrarian longs work.)
 
 ## Style Guidance
 
@@ -57,8 +74,8 @@ Absence of signal is a valid finding — on most days, for most assets, nothing 
 
 Always factor in the macro header before scoring confidence:
 
-- **Buffett Indicator >200%**: macro environment is historically extreme — raise the bar for "bubble_forming" confidence (market-wide overvaluation is already priced in), lower it for "irrational_panic" (further compression is credible).
-- **Fear & Greed <30**: market-wide fear. "irrational_panic" signals are more credible; "bubble_forming" signals are less credible. NOTE: this is now a hard, code-enforced cap (bubble_forming confidence capped at 5 when F&G < 35) — see the Strategy v2 SHORT Gates above.
+- **Buffett Indicator >{AI_HW_BUFFETT_THRESHOLD:.0f}%**: macro environment is historically extreme — raise the bar for "bubble_forming" confidence (market-wide overvaluation is already priced in), lower it for "irrational_panic" (further compression is credible).
+- **Fear & Greed <{MACRO_FEAR_CAP_THRESHOLD}**: market-wide fear. "irrational_panic" signals are more credible; "bubble_forming" signals are less credible. NOTE: this is a hard, code-enforced cap (bubble_forming confidence capped at {MACRO_BUBBLE_CONF_CAP} when F&G < {MACRO_FEAR_CAP_THRESHOLD}) — see the Strategy v2 SHORT Gates above.
 - **VIX Backwardation** (short-term VIX > long-term VIX3M): real near-term stress. Increases confidence on panic signals by 1-2 points.
 - **Fear & Greed >70 with Buffett Indicator >180%**: compound overvaluation. Raise confidence on "bubble_forming" and "reduce_exposure" calls.
 
@@ -73,13 +90,13 @@ Each asset now includes a **"Long-horizon context"** block with the following fi
 | Field | What it measures | Signal direction |
 |-------|-----------------|-----------------|
 | **Ext vs 200d MA** | How far above/below the 200-day SMA the price sits | >+40% = bubble-watch territory; <-40% = potential capitulation |
-| **Sustained (X/60d)** | Days in the last 60 where extension exceeded +40% | ≥30/60 "⚑ extended" = persistent bubble extension, not a one-day spike |
+| **Sustained (X/60d)** | Days in the last 60 where extension exceeded +40% | ≥{SHORT_SUSTAINED_MIN}/60 "⚑ extended" = persistent bubble extension, not a one-day spike |
 | **6m return** | Raw price momentum over ~6 calendar months | Provides context for whether a single-day spike is part of a longer trend |
 | **Acceleration (30d/6m)** | Fraction of the 6m gain captured in the last 30 days | >0.50 "⚑ parabolic" = late-stage blow-off pattern |
-| **Vol distribution (down÷up)** | Ratio of volume on down-days to volume on up-days over last 20 days | >1.0 "distribution ⚠" = smart-money distributing into retail buying |
+| **Vol distribution (down÷up)** | Ratio of volume on down-days to volume on up-days over last 20 days | >{SHORT_VOL_DIST_MIN:.1f} "distribution ⚠" = smart-money distributing into retail buying |
 | **2y peak drawdown** | Distance from the 2-year rolling high | < -40% with many days since peak = potential capitulation candidate |
 
-**How to use**: if today's signal is a single-day spike (z30 high, volume high) but **Sustained < 5/60** and **Ext vs 200d MA < +20%**, that is strong evidence of a news reaction rather than a structural bubble — weight this as context when writing the `reasoning` field. Conversely, if a ticker shows **Sustained ≥ 30/60** and **acceleration ⚑ parabolic**, note that explicitly in reasoning as additional context supporting any `bubble_forming` classification already triggered by the Divergence Rules.
+**How to use**: if today's signal is a single-day spike (z30 high, volume high) but **Sustained < 5/60** and **Ext vs 200d MA < +20%**, that is strong evidence of a news reaction rather than a structural bubble — weight this as context when writing the `reasoning` field. Conversely, if a ticker shows **Sustained ≥ {SHORT_SUSTAINED_MIN}/60** and **acceleration ⚑ parabolic**, note that explicitly in reasoning as additional context supporting any `bubble_forming` classification already triggered by the Divergence Rules.
 
 ## Confidence Calibration
 
@@ -99,20 +116,20 @@ JSON_OUTPUT:
 [Single JSON array — one object per asset analyzed, no markdown fences]
 
 Each object in the array:
-{
+{{
   "ticker": "the ticker symbol analyzed",
   "classification": "irrational_panic|bubble_forming|institutional_rebalancing|silent_accumulation|ambiguous|no_signal",
   "recommendation": "contrarian_buy|reduce_exposure|wait|no_action",
   "reasoning": "2-3 short sentences under 400 characters. Cite specific signals: volume ratio, z-scores, social heat level, tone.",
   "confidence": 1-10
-}
+}}
 
 Constraints:
 - HUMAN_SUMMARY must be in Portuguese, conversational tone, under 600 characters total. Count before returning.
 - JSON_OUTPUT is the array described above; format is otherwise unchanged.
 - Both sections are required and must appear under the exact labels HUMAN_SUMMARY: and JSON_OUTPUT:.
 - reasoning MUST be under 400 characters. Cite the specific signals relied on (e.g., "volume 3.1x, z30=+2.4, heat=explosive, tone=bearish"). No generic language like "monitor the situation".
-- contrarian_buy only when confidence ≥ 7.
+- contrarian_buy only when confidence ≥ {MIN_LONG_CONFIDENCE}.
 - no_signal must always pair with no_action.
 - Never add disclaimers about not being a financial advisor.
 """

--- a/claude_advisor/signal_gates.py
+++ b/claude_advisor/signal_gates.py
@@ -16,7 +16,7 @@ Rules (applied in order, to every ``bubble_forming`` / ``reduce_exposure``
 SHORT candidate):
 
 1. AI-hardware-in-bull reclassification (Part 4):
-   semis sector AND Buffett > 200% AND |z200| elevated AND vol_dist < 1.0
+   semis sector AND Buffett > 200% AND z200 elevated (≥ +2) AND vol_dist ≤ 1.0
    → ``institutional_rebalancing`` / ``wait``.
 2. Volume-distribution gate (Part 2, PRIMARY):
    requires vol_dist > 1.0 (down-day volume exceeds up-day volume = real
@@ -57,6 +57,13 @@ SHORT_SUSTAINED_MIN   = 30     # sustained_days_60 floor
 
 MACRO_FEAR_CAP_THRESHOLD = 35  # Fear & Greed strictly below this caps bubble conf
 MACRO_BUBBLE_CONF_CAP    = 5   # capped confidence (below MIN_SHORT_CONFIDENCE)
+
+# Actionable-confidence floors (single source of truth — the prompt and the
+# recommendation parser both reference these). A short below 6 or a long below
+# 7 is an observation, not a trade. MACRO_BUBBLE_CONF_CAP sits deliberately
+# below MIN_SHORT_CONFIDENCE so a fear-capped bubble short can never open.
+MIN_SHORT_CONFIDENCE = 6
+MIN_LONG_CONFIDENCE  = 7
 
 AI_HW_SECTOR            = "semis"
 AI_HW_BUFFETT_THRESHOLD = 200.0  # Buffett Indicator % above which AI-hw rule arms
@@ -146,16 +153,18 @@ def gate_signal(
     buffett   = _buffett_pct(macro)
 
     # ── Rule 1: AI-hardware-in-bull reclassification ─────────────────────────
+    # z200 must be elevated to the UPSIDE: a deeply negative z200 is a crash,
+    # not institutional AI-capex demand, and must not arm this rule.
     if (
         sector == AI_HW_SECTOR
         and buffett is not None and buffett > AI_HW_BUFFETT_THRESHOLD
-        and z200 is not None and abs(z200) >= AI_HW_Z200_THRESHOLD
-        and vol_dist is not None and vol_dist < SHORT_VOL_DIST_MIN
+        and z200 is not None and z200 >= AI_HW_Z200_THRESHOLD
+        and vol_dist is not None and vol_dist <= SHORT_VOL_DIST_MIN
     ):
         _reclassify(
             signal, "ai_hardware_bull",
-            f"semis + Buffett {buffett:.0f}% + |z200|={abs(z200):.1f} + "
-            f"vol_dist={vol_dist:.2f}<1.0 → institutional demand, not euphoria",
+            f"semis + Buffett {buffett:.0f}% + z200=+{z200:.1f} + "
+            f"vol_dist={vol_dist:.2f}≤1.0 → institutional demand, not euphoria",
         )
         return signal
 

--- a/collectors/market_data.py
+++ b/collectors/market_data.py
@@ -126,7 +126,9 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
     volume_dist_ratio     : float | None
         (total volume on down-days) / (total volume on up-days) over the
         last 20 trading days.  > 1.0 signals distribution (more selling
-        pressure than buying pressure).
+        pressure than buying pressure).  Zero-volume rows (futures contract
+        rolls) and flat days (return exactly 0) are excluded — this ratio is
+        the PRIMARY v2 short gate, so roll artifacts must not skew it.
     drawdown_from_peak_2y : float | None
         (current_price / 2y_rolling_peak) - 1.  Always ≤ 0.
         E.g. -0.65 → price is 65 % below its 2-year high.
@@ -143,18 +145,24 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
         "days_since_peak_2y":     None,
     }
 
-    try:
-        n = len(closes)
+    # Each metric is guarded independently so a failure in one cannot blank
+    # out the others — volume_dist_ratio in particular is the PRIMARY v2
+    # short gate and must survive an error in an unrelated metric.
+    n = len(closes)
 
-        # ── 200d SMA and price extension ──────────────────────────────────────
+    # ── 200d SMA and price extension ──────────────────────────────────────────
+    try:
         if n >= 200:
             sma_200 = float(closes.iloc[-200:].mean())
             if sma_200 > 0:
                 out["price_extension_200d"] = round(
                     (current_price / sma_200) - 1.0, 4
                 )
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"long_horizon: price_extension_200d error: {exc}")
 
-        # ── Sustained extension: days in last 60 where close > 40 % above SMA ─
+    # ── Sustained extension: days in last 60 where close > 40 % above SMA ─────
+    try:
         if n >= 260:
             rolling_sma = closes.rolling(window=200, min_periods=200).mean()
             ext_series = (closes / rolling_sma) - 1.0
@@ -164,8 +172,11 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
             # Enough for a single SMA reading but not a rolling window of 60.
             # Report 0; the field is valid but the sustained window is incomplete.
             out["sustained_days_60"] = 0
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"long_horizon: sustained_days_60 error: {exc}")
 
-        # ── 6-month return (~126 trading days) ────────────────────────────────
+    # ── 6-month return (~126 trading days) + acceleration ratio ───────────────
+    try:
         if n >= 127:
             price_6m_ago = float(closes.iloc[-127])
             if price_6m_ago > 0:
@@ -173,7 +184,6 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
                     (current_price / price_6m_ago) - 1.0, 4
                 )
 
-        # ── Acceleration ratio ────────────────────────────────────────────────
         ret_6m = out["return_6m"]
         if ret_6m is not None and n >= 31:
             price_30d_ago = float(closes.iloc[-31])
@@ -184,18 +194,29 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
                 else:
                     # 6m return is zero or negative — no positive gains to accelerate
                     out["acceleration_ratio"] = 0.0
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"long_horizon: return_6m/acceleration error: {exc}")
 
-        # ── Volume distribution (last 20 trading days) ────────────────────────
+    # ── Volume distribution (last 20 trading days) ─────────────────────────────
+    # Zero-volume rows are contract-roll artifacts in yfinance futures data
+    # (same issue as Fix 1 on avg_volume_30d); flat days carry no directional
+    # information. Both are excluded from the up/down sums.
+    try:
         if len(returns) >= 20:
             rets_20 = returns.tail(20)
             vols_20 = volumes.loc[rets_20.index]
-            up_mask = rets_20.values > 0
-            up_vol  = float(vols_20.values[up_mask].sum())
-            down_vol = float(vols_20.values[~up_mask].sum())
+            valid     = vols_20.values > 0
+            up_mask   = (rets_20.values > 0) & valid
+            down_mask = (rets_20.values < 0) & valid
+            up_vol   = float(vols_20.values[up_mask].sum())
+            down_vol = float(vols_20.values[down_mask].sum())
             if up_vol > 0:
                 out["volume_dist_ratio"] = round(down_vol / up_vol, 3)
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"long_horizon: volume_dist_ratio error: {exc}")
 
-        # ── 2-year peak drawdown ──────────────────────────────────────────────
+    # ── 2-year peak drawdown ───────────────────────────────────────────────────
+    try:
         if n >= 1:
             peak_price = float(closes.max())
             if peak_price > 0:
@@ -204,9 +225,8 @@ def _compute_long_horizon(closes, returns, volumes, current_price: float) -> dic
                 )
                 peak_pos = int(closes.values.argmax())
                 out["days_since_peak_2y"] = n - 1 - peak_pos
-
     except Exception as exc:  # pragma: no cover
-        logger.warning(f"long_horizon computation error: {exc}")
+        logger.warning(f"long_horizon: peak drawdown error: {exc}")
 
     return out
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -64,8 +64,12 @@ MODEL_PRIMARY  = "claude-opus-4-7"
 MODEL_FALLBACK = "claude-sonnet-4-6"
 
 # Claude call knobs
-CLAUDE_MAX_TOKENS  = 600
+CLAUDE_MAX_TOKENS  = 600   # per-ticker calls (future advisor.py)
 CLAUDE_TEMPERATURE = 0.3
+
+# The daily classifier answers for ALL flagged assets in one call
+# (HUMAN_SUMMARY + full JSON array), so it needs a larger budget.
+CLAUDE_MAX_TOKENS_DAILY = 2048
 
 # Dynamic ticker management
 MAX_DYNAMIC_TICKERS         = 15   # cap on simultaneously tracked dynamic tickers

--- a/main.py
+++ b/main.py
@@ -328,22 +328,27 @@ def _attach_sizing_blocks(
     buffett: dict | None,
     fear_greed: dict | None,
     logs_dir: str = LOGS_DIR,
+    classified_signals: list[dict] | None = None,
 ) -> None:
-    """Read classified signals for `date` and attach a sizing_block to each result.
+    """Attach a sizing_block to each result with a classified signal.
 
-    Mutates results in-place.  Silently no-ops when the signals JSON is absent
-    (manual-paste workflow) or when any individual computation fails.
+    Uses ``classified_signals`` directly when the caller already holds the
+    gated/boosted in-memory list (the automated pipeline); otherwise falls
+    back to reading logs/signals_<date>.json (manual-paste workflow).
+    Mutates results in-place.  Silently no-ops when no signals are available
+    or when any individual computation fails.
     """
     from analyzers.position_sizing import compute_sizing_block
 
-    signals_path = os.path.join(logs_dir, f"signals_{date.isoformat()}.json")
-    classified_signals: list[dict] = []
-    if os.path.exists(signals_path):
-        try:
-            with open(signals_path, encoding="utf-8") as fh:
-                classified_signals = json.load(fh).get("signals", [])
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("position sizing: could not load %s: %s", signals_path, exc)
+    if not classified_signals:
+        signals_path = os.path.join(logs_dir, f"signals_{date.isoformat()}.json")
+        classified_signals = []
+        if os.path.exists(signals_path):
+            try:
+                with open(signals_path, encoding="utf-8") as fh:
+                    classified_signals = json.load(fh).get("signals", [])
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("position sizing: could not load %s: %s", signals_path, exc)
 
     if not classified_signals:
         return
@@ -377,6 +382,18 @@ def _attach_sizing_blocks(
                 )
         except Exception as exc:
             logger.warning("position sizing: failed for %s: %s", r["ticker"], exc)
+
+
+def _persist_signals(
+    signals: list[dict], date: dt.date, logs_dir: str = LOGS_DIR
+) -> None:
+    """Write the classified signals to logs/signals_<date>.json (best effort)."""
+    signals_path = os.path.join(logs_dir, f"signals_{date.isoformat()}.json")
+    try:
+        with open(signals_path, "w", encoding="utf-8") as fh:
+            json.dump({"date": date.isoformat(), "signals": signals}, fh, indent=2)
+    except OSError as exc:
+        logger.warning("signals: could not persist %s (%s)", signals_path, exc)
 
 
 def archive_log(report_path: str, date: dt.date, logs_dir: str = LOGS_DIR) -> str:
@@ -607,71 +624,38 @@ def main(argv: list[str]) -> int:
     # pressure. Enforce them in code AFTER classification: reclassify bubble
     # shorts lacking distribution / sustained extension to institutional_
     # rebalancing → wait, and cap fear-regime bubble confidence. Longs untouched.
-    # Re-persist so the cluster booster, sizing, and email all read gated values.
     if _classified_signals:
         from claude_advisor.signal_gates import apply_short_gates
         _macro_for_gates = {"fear_greed": fear_greed, "buffett": buffett}
         apply_short_gates(_classified_signals, results, _macro_for_gates)
-        _signals_path = os.path.join(LOGS_DIR, f"signals_{date.isoformat()}.json")
-        try:
-            with open(_signals_path, "w", encoding="utf-8") as _sf:
-                json.dump({"date": date.isoformat(), "signals": _classified_signals}, _sf, indent=2)
-        except OSError as _exc:
-            logger.warning("v2 gates: could not re-persist %s (%s)", _signals_path, _exc)
+        # Re-persist so today's file holds gated values when detect_clusters
+        # (below) reads it alongside the historical files.
+        _persist_signals(_classified_signals, date)
 
     # ── Cluster Signal Booster ────────────────────────────────────────────────
-    # Reads historical logs/signals_YYYYMMDD.json files (written by this block
-    # on previous runs) and boosts confidence when 3+ tickers from the same
-    # sector are signalling in the same direction within the rolling window.
-    # Post-classification, pure Python — never touches the Claude prompt.
+    # Reads the logs/signals_YYYY-MM-DD.json files persisted by _persist_signals
+    # and boosts confidence when 3+ tickers from the same sector are
+    # signalling in the same direction within the rolling window. Operates
+    # on the gated in-memory list so email, sizing, and the persisted file all
+    # see the same values; signals capped by the macro fear gate are never
+    # boosted (see apply_cluster_boosts).
     active_clusters: list[dict] = []
     if CLUSTER_BOOST_ENABLED:
-        from tracker.cluster_detector import detect_clusters
-        from tracker.sectors import get_direction_group, get_sector
+        from tracker.cluster_detector import apply_cluster_boosts, detect_clusters
 
         active_clusters = detect_clusters(days_window=5)
 
-        # Load today's classified signals (written by the Claude Haiku step)
-        signals_path = os.path.join(LOGS_DIR, f"signals_{date.isoformat()}.json")
-        classified_signals: list[dict] = []
-        if os.path.exists(signals_path):
-            try:
-                with open(signals_path, "r", encoding="utf-8") as fh:
-                    classified_signals = json.load(fh).get("signals", [])
-            except (json.JSONDecodeError, OSError) as exc:
-                logger.warning("cluster boost: could not load %s (%s)", signals_path, exc)
-
-        for signal in classified_signals:
-            sector = get_sector(signal["ticker"])
-            direction = get_direction_group(
-                signal.get("classification", ""),
-                signal.get("recommendation", ""),
-            )
-            for cluster in active_clusters:
-                if cluster["sector"] == sector and cluster["direction_group"] == direction:
-                    original = signal["confidence"]
-                    boosted  = min(original + cluster["boost"], 10)
-                    signal["cluster_boost"] = {
-                        "sector": sector,
-                        "direction_group": direction,
-                        "count": cluster["count"],
-                        "original_confidence": original,
-                        "boost_amount": cluster["boost"],
-                    }
-                    signal["confidence"] = boosted
-                    logger.info(
-                        "[CLUSTER BOOST] %s %s %s: %d -> %d (+%d, %d tickers)",
-                        signal["ticker"], sector, direction,
-                        original, boosted, cluster["boost"], cluster["count"],
-                    )
-                    break
-
-        # Merge cluster_boost info into results for the email template
-        classified_by_ticker = {s["ticker"]: s for s in classified_signals}
-        for r in results:
-            cb = classified_by_ticker.get(r["ticker"], {}).get("cluster_boost")
-            if cb:
-                r["cluster_boost"] = cb
+        if active_clusters and _classified_signals:
+            apply_cluster_boosts(_classified_signals, active_clusters)
+            # Re-persist so the on-disk record carries the boost annotations
+            # that email and sizing see in memory.
+            _persist_signals(_classified_signals, date)
+            # Merge cluster_boost info into results for the email template
+            classified_by_ticker = {s["ticker"]: s for s in _classified_signals}
+            for r in results:
+                cb = classified_by_ticker.get(r["ticker"], {}).get("cluster_boost")
+                if cb:
+                    r["cluster_boost"] = cb
 
         # Persist detected clusters for historical analysis / backtesting
         if active_clusters:
@@ -685,11 +669,13 @@ def main(argv: list[str]) -> int:
                 logger.warning("cluster boost: could not save clusters (%s)", exc)
 
     # ── Position Sizing ───────────────────────────────────────────────────────
-    # Reads classified signals (written by the Claude advisor / add_recommendations
-    # workflow) and attaches a sizing_block to each result for email rendering.
-    # Silently skipped when the signals file is absent (manual-paste workflow).
-    # _attach_sizing_blocks picks up in-memory cluster_boost already merged into results.
-    _attach_sizing_blocks(results, date, buffett, fear_greed)
+    # Attaches a sizing_block to each result for email rendering, using the
+    # in-memory gated+boosted signals; falls back to the signals file when the
+    # automated classifier was skipped (manual-paste workflow).
+    _attach_sizing_blocks(
+        results, date, buffett, fear_greed,
+        classified_signals=_classified_signals,
+    )
 
     # ── GitHub Pages — full report ────────────────────────────────────────────
     # Publish the complete HTML email to docs/reports/YYYY-MM-DD.html so the

--- a/output/document_builder.py
+++ b/output/document_builder.py
@@ -271,11 +271,15 @@ def _asset_section(ticker: str, signals: dict, tier: str) -> str:
 
 
 def _closing_instruction(n_assets: int) -> str:
+    # Must match the Output Contract in claude_advisor/prompts.py — the
+    # classifier's parser expects the HUMAN_SUMMARY / JSON_OUTPUT labels.
     return (
         f"\n{'=' * 72}\n"
         f"[INSTRUCTION]\n\n"
-        f"Analyze each of the {n_assets} asset(s) above and respond with a single "
-        f"JSON array. Each element must follow this exact schema:\n\n"
+        f"Analyze each of the {n_assets} asset(s) above and respond using the "
+        f"exact two-section format from the system prompt: a HUMAN_SUMMARY: "
+        f"section followed by a JSON_OUTPUT: section containing a single JSON "
+        f"array. Each element of the array must follow this exact schema:\n\n"
         f"{{\n"
         f'  "ticker": "...",\n'
         f'  "classification": "bubble_forming|irrational_panic|institutional_rebalancing|silent_accumulation|ambiguous|no_signal",\n'
@@ -283,7 +287,7 @@ def _closing_instruction(n_assets: int) -> str:
         f'  "reasoning": "2-3 short sentences, under 400 characters total",\n'
         f'  "confidence": <integer 1-10>\n'
         f"}}\n\n"
-        f"Return ONLY the JSON array, no prose, no markdown fences.\n"
+        f"No markdown fences, no prose outside the two labelled sections.\n"
     )
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -70,10 +70,26 @@ def test_case_insensitive_section_label():
     assert len(result) == 2
 
 
+# ── bare array fallback (no JSON_OUTPUT label) ────────────────────────────────
+
+def test_bare_array_without_label_falls_back():
+    """Model returns only the array (obeying the report footer instead of the
+    two-section contract) → fallback parse must still succeed."""
+    result = _parse_json_section(_SAMPLE_JSON)
+    assert len(result) == 2
+    assert result[1]["ticker"] == "NVDA"
+
+
+def test_fenced_array_without_label_falls_back():
+    """Bare fenced array without the JSON_OUTPUT label also parses."""
+    result = _parse_json_section(f"```json\n{_SAMPLE_JSON}\n```")
+    assert len(result) == 2
+
+
 # ── error cases ───────────────────────────────────────────────────────────────
 
 def test_missing_json_output_section_raises():
-    """Missing JSON_OUTPUT: label must raise ValueError."""
+    """No JSON_OUTPUT: label AND no bare array anywhere must raise ValueError."""
     with pytest.raises(ValueError, match="JSON_OUTPUT section not found"):
         _parse_json_section("HUMAN_SUMMARY:\nSome text.\n\nNo JSON section here.")
 

--- a/tests/test_cluster_detector.py
+++ b/tests/test_cluster_detector.py
@@ -17,7 +17,7 @@ import os
 
 import pytest
 
-from tracker.cluster_detector import detect_clusters
+from tracker.cluster_detector import apply_cluster_boosts, detect_clusters
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -164,3 +164,55 @@ def test_out_of_window_no_cluster(tmp_path):
     )
     clusters = detect_clusters(days_window=5, logs_dir=str(tmp_path), reference_date=_REF)
     assert clusters == [], "Signals from 8 bdays ago must not trigger a 5-day cluster"
+
+
+# ── apply_cluster_boosts ──────────────────────────────────────────────────────
+
+_SEMIS_BEARISH_CLUSTER = {
+    "sector": "semis",
+    "direction_group": "bearish_overheating",
+    "tickers": ["AMD", "NVDA", "SMCI"],
+    "count": 3,
+    "boost": 1,
+    "first_seen": "2026-05-04",
+    "last_seen": "2026-05-06",
+}
+
+
+def test_boost_applies_to_matching_signal():
+    sig = _sig("NVDA", "bubble_forming", "reduce_exposure", 7)
+    apply_cluster_boosts([sig], [_SEMIS_BEARISH_CLUSTER])
+    assert sig["confidence"] == 8
+    assert sig["cluster_boost"]["original_confidence"] == 7
+    assert sig["cluster_boost"]["boost_amount"] == 1
+    assert sig["cluster_boost"]["sector"] == "semis"
+
+
+def test_boost_never_rearms_macro_capped_signal():
+    """A bubble short capped to 5 by the macro fear gate must NOT be boosted
+    back above MIN_SHORT_CONFIDENCE — that would silently defeat the cap."""
+    sig = _sig("NVDA", "bubble_forming", "reduce_exposure", 5)
+    sig["v2_gate"] = {
+        "action": "confidence_capped",
+        "rule": "macro_fear_cap",
+        "original_confidence": 8,
+    }
+    apply_cluster_boosts([sig], [_SEMIS_BEARISH_CLUSTER])
+    assert sig["confidence"] == 5
+    assert "cluster_boost" not in sig
+
+
+def test_boost_caps_confidence_at_ten():
+    sig = _sig("NVDA", "bubble_forming", "reduce_exposure", 10)
+    apply_cluster_boosts([sig], [_SEMIS_BEARISH_CLUSTER])
+    assert sig["confidence"] == 10
+
+
+def test_boost_ignores_non_matching_sector_or_direction():
+    other_sector = _sig("AAPL", "bubble_forming", "reduce_exposure", 7)   # mega_tech
+    other_dir    = _sig("NVDA", "irrational_panic", "contrarian_buy", 7)  # bullish
+    apply_cluster_boosts([other_sector, other_dir], [_SEMIS_BEARISH_CLUSTER])
+    assert other_sector["confidence"] == 7
+    assert other_dir["confidence"] == 7
+    assert "cluster_boost" not in other_sector
+    assert "cluster_boost" not in other_dir

--- a/tests/test_long_horizon.py
+++ b/tests/test_long_horizon.py
@@ -233,6 +233,49 @@ def test_volume_dist_ratio_all_up_days():
     assert result["volume_dist_ratio"] == pytest.approx(0.0, abs=1e-3)
 
 
+def test_volume_dist_ratio_excludes_flat_days():
+    """Flat days (return exactly 0) carry no directional information and must
+    not be counted as down-day volume, even with huge volume on them."""
+    # Alternate up day / flat day: 10 up days (vol 1M) + 10 flat days (vol 10M)
+    # in the 20-day window. Counting flat as "down" would give ratio = 10.0.
+    prices: list[float] = [100.0]
+    for _ in range(12):
+        prices.append(prices[-1] + 1.0)   # up day
+        prices.append(prices[-1])         # flat day
+    vols = [1_000_000.0]
+    for i in range(1, len(prices)):
+        vols.append(10_000_000.0 if prices[i] == prices[i - 1] else 1_000_000.0)
+    closes  = _make_closes(prices)
+    volumes = _make_volumes(vols, closes)
+    returns = _returns(closes)
+    result  = _compute_long_horizon(closes, returns, volumes, prices[-1])
+    assert result["volume_dist_ratio"] == pytest.approx(0.0, abs=1e-3)
+
+
+def test_volume_dist_ratio_excludes_zero_volume_days():
+    """Zero-volume rows (futures contract-roll artifacts) are excluded from
+    both sides of the ratio."""
+    # 10 up days vol 2M, 10 down days vol 1M → ratio 0.5; sprinkle zero-volume
+    # rows on two of the up days — they must drop out of the up sum.
+    prices: list[float] = [100.0]
+    for _ in range(12):
+        prices.append(prices[-1] + 1.0)   # up day
+        prices.append(prices[-1] - 0.5)   # down day
+    vols = [1_000_000.0]
+    for i in range(1, len(prices)):
+        vols.append(2_000_000.0 if prices[i] > prices[i - 1] else 1_000_000.0)
+    # Zero out the volume on the last two up days (roll artifact).
+    up_positions = [i for i in range(1, len(prices)) if prices[i] > prices[i - 1]]
+    for pos in up_positions[-2:]:
+        vols[pos] = 0.0
+    closes  = _make_closes(prices)
+    volumes = _make_volumes(vols, closes)
+    returns = _returns(closes)
+    result  = _compute_long_horizon(closes, returns, volumes, prices[-1])
+    # Window has 10 down days × 1M = 10M; up volume = 8 × 2M = 16M → 0.625
+    assert result["volume_dist_ratio"] == pytest.approx(10.0 / 16.0, abs=1e-3)
+
+
 def test_volume_dist_ratio_all_down_days():
     """20 consecutive down-days → up_vol = 0 → ratio is None (no up volume)."""
     n = 25

--- a/tests/test_recommendation_parser.py
+++ b/tests/test_recommendation_parser.py
@@ -1,0 +1,94 @@
+"""Tests for tracker/recommendation_parser.py.
+
+Covers the code-enforced actionable-confidence floors (shorts ≥ 6, longs ≥ 7)
+and robust per-recommendation confidence parsing (a malformed value must not
+abort the whole batch).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import tracker.recommendation_parser as rp
+
+
+def _patch_tracker(monkeypatch, price: float | None = 100.0) -> list[dict]:
+    """Stub out the live price fetch and position persistence."""
+    added: list[dict] = []
+
+    def _fake_add(**kwargs):
+        added.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(rp, "fetch_price", lambda ticker: price)
+    monkeypatch.setattr(rp, "add_position", _fake_add)
+    return added
+
+
+_DATE = dt.date(2026, 6, 8)
+
+
+def _rec(ticker: str, recommendation: str, confidence) -> dict:
+    return {
+        "ticker": ticker,
+        "classification": "bubble_forming",
+        "recommendation": recommendation,
+        "reasoning": "test",
+        "confidence": confidence,
+    }
+
+
+def test_short_below_floor_is_skipped(monkeypatch):
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add([_rec("NVDA", "reduce_exposure", 5)], date=_DATE)
+    assert added == []
+
+
+def test_short_at_floor_is_added(monkeypatch):
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add([_rec("NVDA", "reduce_exposure", 6)], date=_DATE)
+    assert len(added) == 1
+    assert added[0]["direction"] == "short"
+    assert added[0]["confidence"] == 6
+
+
+def test_long_below_floor_is_skipped(monkeypatch):
+    """contrarian_buy requires confidence ≥ 7 — enforced in code, not just prompt."""
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add([_rec("SOFI", "contrarian_buy", 6)], date=_DATE)
+    assert added == []
+
+
+def test_long_at_floor_is_added(monkeypatch):
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add([_rec("SOFI", "contrarian_buy", 7)], date=_DATE)
+    assert len(added) == 1
+    assert added[0]["direction"] == "long"
+
+
+def test_malformed_confidence_does_not_abort_batch(monkeypatch):
+    """A string confidence defaults to 5 (below both floors → skipped) and the
+    remaining recommendations are still processed."""
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add(
+        [
+            _rec("NVDA", "reduce_exposure", "high"),
+            _rec("SOFI", "contrarian_buy", 8),
+        ],
+        date=_DATE,
+    )
+    assert [p["ticker"] for p in added] == ["SOFI"]
+
+
+def test_confidence_clamped_to_valid_range(monkeypatch):
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add([_rec("NVDA", "reduce_exposure", 15)], date=_DATE)
+    assert added[0]["confidence"] == 10
+
+
+def test_non_directional_recommendations_skipped(monkeypatch):
+    added = _patch_tracker(monkeypatch)
+    rp.parse_and_add(
+        [_rec("NVDA", "wait", 9), _rec("AAPL", "no_action", 9)], date=_DATE
+    )
+    assert added == []

--- a/tracker/cluster_detector.py
+++ b/tracker/cluster_detector.py
@@ -1,7 +1,7 @@
 """Cluster signal booster — detects when 3+ tickers from the same sector
 receive same-direction classifications within a rolling business-day window.
 
-Signal logs are read from logs/signals_YYYYMMDD.json files, which are
+Signal logs are read from logs/signals_YYYY-MM-DD.json files, which are
 saved by the pipeline when CLUSTER_BOOST_ENABLED=true.
 
 Each signal file has the shape:
@@ -76,6 +76,7 @@ def detect_clusters(
 
     # cluster_data[sector][direction_group][ticker] = [date_str, ...]
     cluster_data: dict[str, dict[str, dict[str, list[str]]]] = {}
+    unmapped_tickers: set[str] = set()
 
     for day in window_dates:
         log_path = os.path.join(logs_dir, f"signals_{day.isoformat()}.json")
@@ -96,6 +97,10 @@ def detect_clusters(
             sector = get_sector(ticker)
             direction = get_direction_group(classification, recommendation)
             if sector is None or direction is None:
+                # A directional signal on a ticker with no sector mapping can
+                # never join a cluster — surface it so the map gets extended.
+                if ticker and sector is None and direction is not None:
+                    unmapped_tickers.add(ticker)
                 continue
 
             cluster_data.setdefault(sector, {}).setdefault(direction, {}).setdefault(
@@ -104,6 +109,13 @@ def detect_clusters(
             date_str = day.isoformat()
             if date_str not in cluster_data[sector][direction][ticker]:
                 cluster_data[sector][direction][ticker].append(date_str)
+
+    if unmapped_tickers:
+        logger.warning(
+            "cluster_detector: no sector mapping for signalling ticker(s): %s "
+            "— add them to tracker/sectors.SECTOR_MAP to include in clustering",
+            ", ".join(sorted(unmapped_tickers)),
+        )
 
     results: list[dict] = []
     for sector, directions in cluster_data.items():
@@ -130,6 +142,57 @@ def detect_clusters(
             )
 
     return results
+
+
+def apply_cluster_boosts(signals: list[dict], clusters: list[dict]) -> list[dict]:
+    """Boost the confidence of classified signals that belong to an active cluster.
+
+    Mutates ``signals`` in place and returns the list. Each boosted signal gets
+    a ``cluster_boost`` annotation (sector, direction_group, count,
+    original_confidence, boost_amount) for the email/report and sizing.
+
+    Signals whose confidence was capped by the macro fear gate
+    (``v2_gate.action == "confidence_capped"``) are never boosted — boosting a
+    capped bubble short back above MIN_SHORT_CONFIDENCE would silently defeat
+    the cap.
+    """
+    for signal in signals or []:
+        ticker = signal.get("ticker", "")
+        gate = signal.get("v2_gate") or {}
+        if gate.get("action") == "confidence_capped":
+            logger.info(
+                "[CLUSTER BOOST] %s skipped — confidence capped by v2 gate (%s)",
+                ticker, gate.get("rule"),
+            )
+            continue
+
+        sector = get_sector(ticker)
+        direction = get_direction_group(
+            signal.get("classification", ""),
+            signal.get("recommendation", ""),
+        )
+        if sector is None or direction is None:
+            continue
+
+        for cluster in clusters:
+            if cluster["sector"] == sector and cluster["direction_group"] == direction:
+                original = signal.get("confidence", 0)
+                boosted = min(original + cluster["boost"], 10)
+                signal["cluster_boost"] = {
+                    "sector": sector,
+                    "direction_group": direction,
+                    "count": cluster["count"],
+                    "original_confidence": original,
+                    "boost_amount": cluster["boost"],
+                }
+                signal["confidence"] = boosted
+                logger.info(
+                    "[CLUSTER BOOST] %s %s %s: %d -> %d (+%d, %d tickers)",
+                    ticker, sector, direction,
+                    original, boosted, cluster["boost"], cluster["count"],
+                )
+                break
+    return signals
 
 
 if __name__ == "__main__":

--- a/tracker/recommendation_parser.py
+++ b/tracker/recommendation_parser.py
@@ -9,16 +9,30 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
+from claude_advisor.signal_gates import MIN_LONG_CONFIDENCE, MIN_SHORT_CONFIDENCE
 from tracker.position_tracker import add_position, fetch_price
 
 logger = logging.getLogger(__name__)
 
 DIRECTIONAL = {"contrarian_buy", "reduce_exposure"}
 
-# Strategy v2: a SHORT (reduce_exposure) is only actionable at confidence >= 6.
-# The macro fear-cap (claude_advisor/signal_gates.py) caps fear-regime bubble
-# shorts to 5, which falls below this floor and so cannot open a position.
-MIN_SHORT_CONFIDENCE = 6
+DEFAULT_CONFIDENCE = 5
+
+
+def _parse_confidence(raw: object) -> int:
+    """Coerce a recommendation's confidence to an int in [1, 10].
+
+    Malformed or missing values fall back to DEFAULT_CONFIDENCE instead of
+    raising, so one bad recommendation cannot abort the whole batch.
+    """
+    try:
+        confidence = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning(
+            "unparseable confidence %r — defaulting to %d", raw, DEFAULT_CONFIDENCE
+        )
+        confidence = DEFAULT_CONFIDENCE
+    return max(1, min(10, confidence))
 
 
 def parse_and_add(
@@ -53,15 +67,17 @@ def parse_and_add(
             continue
 
         direction = "long" if rec_type == "contrarian_buy" else "short"
-        confidence = int(rec.get("confidence") or 5)
+        confidence = _parse_confidence(rec.get("confidence"))
 
-        # Strategy v2 actionable-confidence floor for shorts. A reduce_exposure
-        # capped to 5 by the macro fear-cap (or otherwise below 6) is an
-        # observation, not a trade.
-        if direction == "short" and confidence < MIN_SHORT_CONFIDENCE:
+        # Strategy v2 actionable-confidence floors, enforced in code (the
+        # prompt states them too, but prompt rules are advisory). A
+        # reduce_exposure capped to 5 by the macro fear-cap (or otherwise
+        # below 6) is an observation, not a trade; contrarian_buy requires 7.
+        floor = MIN_SHORT_CONFIDENCE if direction == "short" else MIN_LONG_CONFIDENCE
+        if confidence < floor:
             logger.info(
-                "%s: skipping short below actionable confidence floor (conf=%d < %d)",
-                ticker, confidence, MIN_SHORT_CONFIDENCE,
+                "%s: skipping %s below actionable confidence floor (conf=%d < %d)",
+                ticker, direction, confidence, floor,
             )
             continue
 

--- a/tracker/sectors.py
+++ b/tracker/sectors.py
@@ -51,6 +51,10 @@ SECTOR_MAP = {
     ],
 }
 
+TICKER_TO_SECTOR = {
+    ticker: sector for sector, tickers in SECTOR_MAP.items() for ticker in tickers
+}
+
 DIRECTION_GROUPS = {
     "bearish_overheating": ["bubble_forming", "reduce_exposure"],
     "bullish_panic": ["irrational_panic", "contrarian_buy"],
@@ -59,10 +63,7 @@ DIRECTION_GROUPS = {
 
 
 def get_sector(ticker: str) -> str | None:
-    for sector, tickers in SECTOR_MAP.items():
-        if ticker in tickers:
-            return sector
-    return None
+    return TICKER_TO_SECTOR.get(ticker)
 
 
 def get_direction_group(classification: str, recommendation: str) -> str | None:


### PR DESCRIPTION
Implements the bubble-code review findings:

- main.py: cluster boost now operates on the in-memory gated signals
  instead of a separately re-loaded copy, so email, sizing, and the
  persisted signals file all see identical values; signals are persisted
  via a single _persist_signals helper (after gating, again after boost).
- cluster_detector: new apply_cluster_boosts() — never boosts a signal
  whose confidence was capped by the macro fear gate, so the boost cannot
  re-arm a blocked bubble short; warns about signalling tickers missing
  from SECTOR_MAP; docstring filename fixed.
- signal_gates: AI-hardware-in-bull rule now requires z200 >= +2 (upside
  extension), not |z200|, so a crash cannot arm it; vol_dist boundary
  aligned with the primary gate (<= 1.0); actionable-confidence floors
  (shorts >= 6, longs >= 7) moved here as the single source of truth.
- prompts: SYSTEM_PROMPT thresholds are now interpolated from the
  signal_gates constants so prompt and code-enforced gates cannot drift;
  macro-context fear threshold harmonized to 35.
- classifier: model/temperature/max-tokens come from config, with
  MODEL_FALLBACK retry; JSON parser falls back to a bare top-level array
  when the JSON_OUTPUT label is absent.
- document_builder: closing instruction now matches the two-section
  HUMAN_SUMMARY / JSON_OUTPUT contract the parser expects.
- market_data: volume_dist_ratio (primary short gate) excludes flat days
  and zero-volume contract-roll rows; each long-horizon metric is guarded
  independently so one failure cannot blank out the others.
- recommendation_parser: per-recommendation confidence parsing (malformed
  values no longer abort the batch, clamped to 1-10) and a code-enforced
  long floor (contrarian_buy requires confidence >= 7).
- sectors: O(1) reverse-map lookup for get_sector.
- tests: 15 new tests (cluster boost cap interaction, bare-array parse
  fallback, vol_dist flat/zero-volume days, recommendation parser floors).

https://claude.ai/code/session_01JwtbZn6GqZM3PhvTd1zvgp