### PR TITLE
fix: buy-floor + artifact containment + volume flag + ETF root-cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 
 cp .env.example .env     # fill in Gmail creds (see below)
-python main.py           # default tickers: NVDA TSLA GC=F
+python main.py           # default tickers: NVDA TSLA GLD ...
 python main.py --no-email
 python main.py NVDA TSLA AAPL
 ```

--- a/analyzers/volume_quality.py
+++ b/analyzers/volume_quality.py
@@ -1,0 +1,125 @@
+"""Containment for suspected volume artifacts (yfinance contract rolls).
+
+yfinance front-month futures symbols silently stitch different contracts'
+histories at roll, injecting fake volume (diagnosed May 2026: GC=F hit 310x
+on May-18; see backtests/VOLUME_FIX*.md). The DATA QUALITY badge and the
+RED-tier suppression contain the display/tier path, but the artifact also
+poisons the v2 ``volume_dist_ratio`` — the PRIMARY bubble-short gate — and
+the classifier's reasoning (2026-06-09: SI=F "Volume 43.2x ... but
+directional", vol_dist 58.84).
+
+This module nulls every volume-derived metric in the DECISION payload when
+the artifact flag fires, so poisoned values cannot reach any gate or any
+classifier reasoning, and writes a running record to
+``logs/volume_artifacts.log`` so the root cause can be investigated and
+fixed (e.g. a continuous-contract data source).
+
+Policy: do NOT try to correct the number — no data is better than poisoned
+data. Mark it unusable, exclude it, and flag it loudly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT_LOG_FILENAME = "volume_artifacts.log"
+
+
+def is_volume_artifact(volume: dict | None) -> bool:
+    """True when the volume analyzer flagged this ticker's volume as a
+    suspected data artifact (data_quality == "suspicious_volume")."""
+    return (volume or {}).get("data_quality") == "suspicious_volume"
+
+
+def sanitize_volume_artifacts(
+    ticker: str,
+    signals: dict,
+    date: dt.date,
+    logs_dir: str = "logs",
+    write_log: bool = True,
+) -> bool:
+    """Null all volume-derived decision metrics for an artifact-flagged ticker.
+
+    Mutates ``signals`` in place:
+      - ``volume["artifact"] = True`` and the raw multiple is preserved under
+        ``volume["raw_ratio"]`` (display/badge/logging only).
+      - ``market.long_horizon.volume_dist_ratio`` → None (raw value preserved
+        under ``raw_volume_dist_ratio``). A null vol_dist FAILS the v2
+        ``> 1.0`` short gate, so the ticker is not eligible for a
+        bubble_forming short.
+
+    The renderer (utils/token_optimizer.compress_signals) keys off
+    ``volume["artifact"]`` to null the volume line in the classifier payload
+    and to print the VOLUME DATA UNRELIABLE investigation flag.
+
+    Returns True when the ticker was flagged (and logged), False otherwise.
+    """
+    volume = signals.get("volume") or {}
+    if not is_volume_artifact(volume):
+        return False
+
+    raw_ratio = volume.get("ratio")
+    volume["artifact"] = True
+    volume["raw_ratio"] = raw_ratio
+
+    lh = (signals.get("market") or {}).get("long_horizon")
+    raw_vol_dist = None
+    if lh is not None:
+        raw_vol_dist = lh.get("volume_dist_ratio")
+        lh["raw_volume_dist_ratio"] = raw_vol_dist
+        lh["volume_dist_ratio"] = None
+
+    logger.warning(
+        "[VOLUME ARTIFACT] %s: vol_multiple=%s and vol_dist=%s nulled — "
+        "excluded from gates and classification (suspected contract-roll artifact)",
+        ticker, raw_ratio, raw_vol_dist,
+    )
+    if write_log:
+        _append_artifact_log(date, ticker, raw_ratio, raw_vol_dist, logs_dir)
+    return True
+
+
+def _append_artifact_log(
+    date: dt.date,
+    ticker: str,
+    raw_ratio: float | None,
+    raw_vol_dist: float | None,
+    logs_dir: str,
+) -> None:
+    """Append one line per flagged ticker to logs/volume_artifacts.log."""
+    path = os.path.join(logs_dir, ARTIFACT_LOG_FILENAME)
+    ratio_s    = f"{raw_ratio:.2f}" if isinstance(raw_ratio, (int, float)) else "n/a"
+    vol_dist_s = f"{raw_vol_dist:.2f}" if isinstance(raw_vol_dist, (int, float)) else "n/a"
+    line = (
+        f"{date.isoformat()} | {ticker} | raw_vol_multiple={ratio_s}x | "
+        f"raw_vol_dist={vol_dist_s} | metrics nulled (suspected contract-roll artifact)\n"
+    )
+    try:
+        os.makedirs(logs_dir, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+    except OSError as exc:
+        logger.warning("volume artifact log: could not write %s (%s)", path, exc)
+
+
+def log_artifact_summary(
+    date: dt.date, tickers: list[str], logs_dir: str = "logs"
+) -> None:
+    """Append a per-run summary line so artifact frequency is visible over time."""
+    if not tickers:
+        return
+    path = os.path.join(logs_dir, ARTIFACT_LOG_FILENAME)
+    line = (
+        f"{date.isoformat()} | SUMMARY | count={len(tickers)} | "
+        f"tickers={','.join(tickers)}\n"
+    )
+    try:
+        os.makedirs(logs_dir, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+    except OSError as exc:
+        logger.warning("volume artifact log: could not write %s (%s)", path, exc)

--- a/claude_advisor/prompts.py
+++ b/claude_advisor/prompts.py
@@ -69,7 +69,7 @@ These rules apply ONLY to SHORT calls (bubble_forming → reduce_exposure). They
 
 ## Style Guidance
 
-Absence of signal is a valid finding — on most days, for most assets, nothing interesting is happening; saying so clearly is more valuable than inventing patterns. Do not apply asset reputation as a prior: analyze the signals as presented; do not assume TSLA is always a bubble or GC=F is always safe.
+Absence of signal is a valid finding — on most days, for most assets, nothing interesting is happening; saying so clearly is more valuable than inventing patterns. Do not apply asset reputation as a prior: analyze the signals as presented; do not assume TSLA is always a bubble or GLD is always safe.
 
 ## Macro Context
 
@@ -82,7 +82,7 @@ Always factor in the macro header before scoring confidence:
 
 ## Special Notes
 
-- **Commodities (GC=F, SI=F, CL=F, HG=F, ZS=F, NG=F)**: naturally attract institutional volume with low retail chatter. Default toward "institutional_rebalancing" unless YouTube heat is clearly "elevated" or "explosive" AND tone is non-neutral. Gold and silver in particular have deep institutional markets; anomalous volume without social heat is almost always institutional.
+- **Commodities & metal ETFs (GLD, SLV, COPX, CL=F, ZS=F, NG=F)**: naturally attract institutional volume with low retail chatter. Default toward "institutional_rebalancing" unless YouTube heat is clearly "elevated" or "explosive" AND tone is non-neutral. Gold and silver in particular have deep institutional markets; anomalous volume without social heat is almost always institutional. COPX is a copper-miners equity ETF — treat it as the copper proxy, but remember it carries equity beta on top of the metal.
 
 ## Long-Horizon Context (v2 — Observation Mode)
 

--- a/claude_advisor/prompts.py
+++ b/claude_advisor/prompts.py
@@ -56,6 +56,7 @@ Apply these rules before anything else. They override any pattern-matching insti
 - If Volume >3x AND Social Heat is "explosive" AND tone is "bullish" → MUST classify as "bubble_forming".
 - Social Heat alone (without volume confirmation ≥ 2x) → always "ambiguous" or "no_signal". Do not manufacture a conviction call from social data alone.
 - z-scores between -1.5 and +1.5 are noise, not signal, even when volume is elevated.
+- If a ticker's volume is flagged as a suspected data artifact, its volume multiple and volume_distribution are UNRELIABLE and set to null. Do not use them as evidence for any directional call — not even hedged ("possible artifact, but directional" is forbidden reasoning). Base the classification on price velocity (z-scores), RSI, long-horizon extension, and social signals only. With volume excluded, the volume-dependent Divergence Rules above cannot fire; the ceiling for such a ticker is "ambiguous" unless the remaining signals alone satisfy a rule.
 
 ## Strategy v2 SHORT Gates (MANDATORY — also enforced in code)
 

--- a/claude_advisor/signal_gates.py
+++ b/claude_advisor/signal_gates.py
@@ -8,20 +8,28 @@ showed the model issued high-confidence bubble shorts straight into institutiona
 accumulation regardless of the prompt guidance.
 
 This module enforces those rules in code, after classification, so they cannot
-be ignored.  It only ever *tightens* SHORT signals — long signals
-(``irrational_panic`` → ``contrarian_buy``) are never touched, per the
-retrospective finding that the long side went 2/2.
+be ignored.  SHORT signals are tightened by rules 1-4 below.  LONG signals
+(``irrational_panic`` → ``contrarian_buy``) are never reclassified and never
+confidence-capped, per the retrospective finding that the long side went 2/2 —
+but a contrarian_buy below MIN_LONG_CONFIDENCE is downgraded to ``wait``
+(rule 0): the 2026-06-09 digest emitted a confidence-5 SI=F buy as actionable
+even though the prompt has always required ≥ 7, proving the floor must live in
+code.
 
-Rules (applied in order, to every ``bubble_forming`` / ``reduce_exposure``
-SHORT candidate):
+Rules (applied in order):
 
+0. Buy-confidence floor (longs):
+   ``contrarian_buy`` with confidence < MIN_LONG_CONFIDENCE → recommendation
+   ``wait`` (classification untouched — it survives as an observation).
 1. AI-hardware-in-bull reclassification (Part 4):
    semis sector AND Buffett > 200% AND z200 elevated (≥ +2) AND vol_dist ≤ 1.0
    → ``institutional_rebalancing`` / ``wait``.
 2. Volume-distribution gate (Part 2, PRIMARY):
    requires vol_dist > 1.0 (down-day volume exceeds up-day volume = real
    distribution).  Otherwise the move is accumulation, not euphoria →
-   ``institutional_rebalancing`` / ``wait``.
+   ``institutional_rebalancing`` / ``wait``.  A vol_dist of None — including
+   one nulled by the volume-artifact containment
+   (analyzers/volume_quality.py) — always fails this gate.
 3. Sustained-extension gate (Part 4, secondary):
    requires price_extension_200d > 0.60 (single name) / 0.40 (index)
    AND sustained_days_60 >= 30.  Otherwise → ``institutional_rebalancing`` / ``wait``.
@@ -137,8 +145,28 @@ def gate_signal(
     market pipeline; either may be empty/None.  Returns the same dict (mutated)
     for convenient chaining.
     """
+    # ── Rule 0: buy-confidence floor ─────────────────────────────────────────
+    # contrarian_buy requires confidence ≥ MIN_LONG_CONFIDENCE to be
+    # actionable. Below that it is downgraded to wait (classification kept,
+    # so it survives as an observation). Enforced in code because the
+    # 2026-06-09 digest emitted a confidence-5 buy as actionable despite the
+    # prompt-level rule.
+    if signal.get("recommendation") == "contrarian_buy":
+        confidence = signal.get("confidence") or 0
+        if confidence < MIN_LONG_CONFIDENCE:
+            signal["v2_gate"] = {
+                "action": "downgraded",
+                "rule": "buy_conf_floor",
+                "detail": f"contrarian_buy conf={confidence} < {MIN_LONG_CONFIDENCE} "
+                          f"→ wait (observation, not actionable)",
+                "original_recommendation": "contrarian_buy",
+                "original_confidence": confidence,
+            }
+            signal["recommendation"] = WAIT_RECOMMENDATION
+        return signal
+
     if not _is_short(signal):
-        return signal  # never touch longs / waits / no_action
+        return signal  # never touch waits / no_action
 
     lh        = long_horizon or {}
     vel       = velocity or {}
@@ -243,6 +271,7 @@ def apply_short_gates(
     inputs = _gate_inputs_from_results(results)
     reclassified = 0
     capped = 0
+    downgraded = 0
     for signal in signals or []:
         ticker = (signal.get("ticker") or "").upper()
         per    = inputs.get(ticker, {})
@@ -267,9 +296,16 @@ def apply_short_gates(
                 "[V2 GATE] %s confidence %s→%s (%s)",
                 ticker, before_conf, signal.get("confidence"), gate.get("rule"),
             )
-    if reclassified or capped:
+        elif gate and gate.get("action") == "downgraded":
+            downgraded += 1
+            logger.info(
+                "[V2 GATE] %s contrarian_buy conf=%s → wait (%s)",
+                ticker, before_conf, gate.get("rule"),
+            )
+    if reclassified or capped or downgraded:
         logger.info(
-            "[V2 GATE] summary: %d reclassified to wait, %d confidence-capped",
-            reclassified, capped,
+            "[V2 GATE] summary: %d reclassified to wait, %d confidence-capped, "
+            "%d buys downgraded below floor",
+            reclassified, capped, downgraded,
         )
     return signals

--- a/collectors/youtube_sentiment.py
+++ b/collectors/youtube_sentiment.py
@@ -30,12 +30,16 @@ _FINANCIAL_KEYWORDS: frozenset[str] = frozenset([
 
 # Extra domain words for each commodity ticker (in addition to _FINANCIAL_KEYWORDS)
 _COMMODITY_DOMAIN: dict[str, frozenset[str]] = {
-    "GC=F": frozenset(["mining", "ounce", "bullion"]),
-    "SI=F": frozenset(["mining", "ounce"]),
-    "HG=F": frozenset(["mining", "lb", "lme"]),
+    "GLD":  frozenset(["mining", "ounce", "bullion", "gold"]),
+    "SLV":  frozenset(["mining", "ounce", "silver"]),
+    "COPX": frozenset(["mining", "copper", "lb", "lme"]),
     "CL=F": frozenset(["crude", "wti", "brent", "barrel", "opec"]),
     "ZS=F": frozenset(["cbot", "bushel", "harvest"]),
     "NG=F": frozenset(["henry hub", "lng"]),
+    # Retired front-month futures symbols (kept for ad-hoc/CLI runs on legacy symbols)
+    "GC=F": frozenset(["mining", "ounce", "bullion"]),
+    "SI=F": frozenset(["mining", "ounce"]),
+    "HG=F": frozenset(["mining", "lb", "lme"]),
 }
 
 _BEARISH: frozenset[str] = frozenset([

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -18,11 +18,23 @@ US_STOCKS = [
     "RDDT",   # WSB betting on itself
 ]
 
+# Metals use ETF proxies, not front-month futures: yfinance silently stitches
+# futures contracts at roll, injecting fake volume that poisoned vol_multiple
+# and the v2 volume_dist gate (GC=F 310x on 2026-05-18; SI=F vol_dist 58.84 on
+# 2026-06-09 — see logs/volume_artifacts.log and backtests/VOLUME_FIX*.md).
+# ETFs have no contract rolls, so their volume is real and usable by the gates.
+# Copper uses COPX (copper miners, ~millions of shares/day) rather than CPER
+# (pure-price proxy but too thin for volume-based signals) — see
+# scripts/validate_etf_volume.py for the liquidity evidence.
+# TODO: CL=F / ZS=F / NG=F are still front-month futures and rely on the
+# Layer-1 artifact containment (analyzers/volume_quality.py) around rolls;
+# candidate ETF proxies if their volume ever needs to be gate-usable: USO,
+# DBA/SOYB, UNG.
 COMMODITIES = [
-    "GC=F",   # Gold
-    "SI=F",   # Silver
+    "GLD",    # Gold (SPDR Gold Shares — replaces GC=F)
+    "SLV",    # Silver (iShares Silver Trust — replaces SI=F)
     "CL=F",   # Crude oil WTI
-    "HG=F",   # Copper
+    "COPX",   # Copper miners (Global X — replaces HG=F; CPER too thin)
     "ZS=F",   # Soybeans
     "NG=F",   # Natural gas
 ]
@@ -44,12 +56,17 @@ TICKER_NAMES = {
     "SOFI":  "SoFi",
     "MSTR":  "MicroStrategy",
     "RDDT":  "Reddit",
-    "GC=F":  "Gold",
-    "SI=F":  "Silver",
+    "GLD":   "Gold (GLD)",
+    "SLV":   "Silver (SLV)",
     "CL=F":  "Crude Oil WTI",
-    "HG=F":  "Copper",
+    "COPX":  "Copper Miners (COPX)",
     "ZS=F":  "Soybeans",
     "NG=F":  "Natural Gas",
+    # Legacy display names — retired front-month futures symbols still appear
+    # in historical logs, the weekly summary, and old signals files.
+    "GC=F":  "Gold (futures, retired)",
+    "SI=F":  "Silver (futures, retired)",
+    "HG=F":  "Copper (futures, retired)",
 }
 
 # Analyzer thresholds

--- a/config/active_tickers.json
+++ b/config/active_tickers.json
@@ -12,10 +12,10 @@
     "SOFI",
     "MSTR",
     "RDDT",
-    "GC=F",
-    "SI=F",
+    "GLD",
+    "SLV",
     "CL=F",
-    "HG=F",
+    "COPX",
     "ZS=F",
     "NG=F"
   ],

--- a/config/ticker_manager.py
+++ b/config/ticker_manager.py
@@ -37,10 +37,11 @@ logger = logging.getLogger(__name__)
 _STATE_FILE = os.path.join(os.path.dirname(__file__), "active_tickers.json")
 
 # The original 18 tickers are permanently protected — auto-demotion never applies.
+# Metals swapped to ETF proxies (GLD/SLV/COPX) — see config/__init__.py.
 ORIGINAL_18: frozenset[str] = frozenset([
     "NVDA", "TSLA", "AAPL", "AMZN", "GOOGL", "PLTR", "RKLB", "ASTS",
     "MU", "SOFI", "MSTR", "RDDT",
-    "GC=F", "SI=F", "CL=F", "HG=F", "ZS=F", "NG=F",
+    "GLD", "SLV", "CL=F", "COPX", "ZS=F", "NG=F",
 ])
 
 

--- a/delivery/digest_builder.py
+++ b/delivery/digest_builder.py
@@ -73,6 +73,14 @@ def build_digest_html(
         if s.get("recommendation") in ("contrarian_buy", "reduce_exposure")
     ]
 
+    # Tickers whose volume metrics were nulled by the artifact containment
+    # (analyzers/volume_quality.py) — actionable rows for these get a note.
+    artifact_tickers = {
+        r["ticker"] for r in results
+        if (r["signals"].get("volume") or {}).get("artifact")
+        or (r["signals"].get("volume") or {}).get("data_quality") == "suspicious_volume"
+    }
+
     red_count   = sum(1 for r in results if get_alert_tier(r["signals"]) == "red")
     amber_count = sum(1 for r in results if get_alert_tier(r["signals"]) == "amber")
     report_url  = f"{PAGES_BASE_URL}/reports/{date.isoformat()}.html"
@@ -179,6 +187,12 @@ def build_digest_html(
             sb       = sizing_by_ticker.get(ticker)
             size_str = f"{sb['position_size_pct']:.1f}%" if sb else "n/a"
             d10_str  = sb["windows"]["d10"] if sb else "—"
+            artifact_note = ""
+            if ticker in artifact_tickers:
+                artifact_note = (
+                    f"<div style='font-size:10px;color:#f97316;margin-top:3px;'>"
+                    f"&#9888; (volume data excluded &mdash; unreliable)</div>"
+                )
             rows += (
                 f"<div style='border-top:1px solid #27272a;padding:10px 0;'>"
                 f"<div style='display:flex;justify-content:space-between;align-items:center;"
@@ -195,6 +209,7 @@ def build_digest_html(
                 f"</div>"
                 f"<div style='font-size:11px;color:#94a3b8;font-style:italic;'>"
                 f"{html_lib.escape(reason)}</div>"
+                f"{artifact_note}"
                 f"</div>"
             )
         actionable_html = (

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ from analyzers.price_velocity import analyze_price_velocity
 from analyzers.rsi import analyze_rsi
 from analyzers.sentiment_aggregator import aggregate_sentiment
 from analyzers.volume_analyzer import analyze_volume
+from analyzers.volume_quality import log_artifact_summary, sanitize_volume_artifacts
 from collectors.buffett_indicator import fetch_buffett_indicator
 from collectors.buffett_indicator import format_summary as format_buffett
 from collectors.fear_greed import fetch_fear_greed, format_summary as format_fg
@@ -114,14 +115,25 @@ def check_trading_day(date: dt.date) -> tuple[bool, str]:
     return True, "normal trading day"
 
 
-def run_pipeline(tickers: list[str]) -> list[dict]:
+def run_pipeline(
+    tickers: list[str],
+    date: dt.date | None = None,
+    log_artifacts: bool = True,
+) -> list[dict]:
     """Run market + StockTwits for all tickers.
 
     YouTube is fetched separately in main() for RED/AMBER tickers only
     (saves daily API quota). Raw StockTwits result is stored under
     '_st_raw' on each result dict for use during the enrichment step.
+
+    Tickers whose volume is flagged as a suspected data artifact have ALL
+    volume-derived decision metrics nulled (vol multiple in the classifier
+    payload, vol_dist for the v2 short gate) and are recorded in
+    logs/volume_artifacts.log (skipped in debug mode via log_artifacts=False).
     """
+    date = date or dt.date.today()
     results = []
+    artifact_tickers: list[str] = []
     for ticker in tickers:
         logger.info(f"--- {ticker} ---")
         try:
@@ -151,7 +163,19 @@ def run_pipeline(tickers: list[str]) -> list[dict]:
             "rsi":       rsi,
             "sentiment": sentiment,
         }
+
+        # Volume-artifact containment: null poisoned metrics before anything
+        # downstream (tiers excepted — tier suppression has its own guard)
+        # can read them, and log the raw values for root-cause investigation.
+        if sanitize_volume_artifacts(
+            ticker, signals, date, logs_dir=LOGS_DIR, write_log=log_artifacts
+        ):
+            artifact_tickers.append(ticker)
+
         results.append({"ticker": ticker, "signals": signals, "_st_raw": None})
+
+    if log_artifacts and artifact_tickers:
+        log_artifact_summary(date, artifact_tickers, logs_dir=LOGS_DIR)
     return results
 
 
@@ -526,7 +550,7 @@ def main(argv: list[str]) -> int:
     logger.info(format_buffett(buffett))
 
     # ── Pipeline ─────────────────────────────────────────────────────────────
-    results = run_pipeline(tickers)
+    results = run_pipeline(tickers, date=date, log_artifacts=not debug)
     enrich_with_youtube(results)   # YouTube fetched only for RED/AMBER tickers
     print_signal_summary(results)
 

--- a/output/document_builder.py
+++ b/output/document_builder.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import math
 import os
 
 from claude_advisor.prompts import SYSTEM_PROMPT
@@ -29,15 +30,35 @@ AMBER_VOL_THRESHOLD = 1.5
 AMBER_SOCIAL_ZSCORE_THRESHOLD = 2.0
 
 
+def is_null_data(signals: dict) -> bool:
+    """True for pure null-data tickers (e.g. pre-IPO SPCX): NaN/None volume
+    ratio AND z30 == 0 AND z200 == 0 AND no 200d history. Such a ticker has
+    no real signal — NaN volume must not be allowed to read as "extreme" and
+    solo-trigger RED."""
+    ratio = signals["volume"].get("ratio")
+    ratio_null = ratio is None or (isinstance(ratio, float) and math.isnan(ratio))
+    if not ratio_null:
+        return False
+    vel = signals["velocity"]
+    if vel.get("z_score_30d") != 0 or vel.get("z_score_200d") != 0:
+        return False
+    lh = (signals.get("market") or {}).get("long_horizon") or {}
+    return lh.get("price_extension_200d") is None
+
+
 def get_alert_tier(signals: dict) -> str | None:
     """Return 'red', 'amber', or None.
 
+    Null-data tickers (NaN volume + zero z-scores + no 200d history) are
+    always SKIP — see is_null_data().
     Red  — extreme volume (>5x) OR macro_extreme (both |z_30d|>2 AND |z_200d|>2).
     Amber — |z_30d|>1.5 AND vol>1.5x; OR vol>2.5x alone; OR RSI>75/RSI<25;
              OR social_heat_zscore>2.0 with vol>1.0x;
              OR StockTwits heat "elevated"/"explosive" with vol>1.0x.
     Red takes priority; an asset cannot be both.
     """
+    if is_null_data(signals):
+        return None
     vol_class  = signals["volume"]["classification"]
     vol_ratio  = signals["volume"]["ratio"]
     macro_extreme = signals["velocity"].get("macro_extreme", False)
@@ -78,6 +99,11 @@ def passes_prefilter(signals: dict) -> bool:
 
 def get_tier_reason(signals: dict) -> str:
     """Explain which signals triggered the tier, or why the ticker was skipped."""
+    if is_null_data(signals):
+        return (
+            "SKIP: null data — NaN volume, zero z-scores, no 200d history "
+            "(pre-IPO / dead ticker, no real signal)"
+        )
     vol_class = signals["volume"]["classification"]
     vol_ratio = signals["volume"]["ratio"]
     z30 = signals["velocity"]["z_score_30d"]

--- a/scripts/validate_etf_volume.py
+++ b/scripts/validate_etf_volume.py
@@ -1,0 +1,95 @@
+"""Validate that the metal ETF proxies (GLD/SLV/COPX) have clean volume.
+
+The yfinance front-month futures symbols (GC=F/SI=F/HG=F) stitch different
+contracts' histories at roll, injecting fake volume — the artifact signature
+is a 10x+ single-day volume multiple that is not a real market event
+(GC=F hit 310x on 2026-05-18; see backtests/VOLUME_FIX*.md). ETFs have no
+contract rolls, so their volume should never show that signature.
+
+For each symbol this script pulls ~200 trading days and reports:
+  - average / median daily volume (liquidity — the copper CPER-vs-COPX call)
+  - zero-volume day count
+  - the max single-day multiple vs a trailing 30d non-zero baseline
+  - how many days exceeded 5x and 10x
+
+PASS criteria for the new ETF symbols: no zero-volume days, max multiple in a
+sane range (real news days are roughly < 5x; 10x+ is the artifact signature).
+The legacy futures symbols are included for the before/after comparison.
+
+Usage (requires network access to Yahoo Finance — run locally or in CI):
+    python scripts/validate_etf_volume.py
+Exit code 1 if any NEW symbol shows the artifact signature.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import yfinance as yf
+
+NEW_SYMBOLS    = ["GLD", "SLV", "COPX", "CPER"]   # CPER shown for the copper decision record
+LEGACY_FUTURES = ["GC=F", "SI=F", "HG=F"]
+ACTIVE_NEW     = {"GLD", "SLV", "COPX"}            # the symbols actually in the universe
+
+MAX_SANE_MULTIPLE = 10.0    # the artifact signature threshold (matches analyze_volume)
+
+
+def volume_stats(ticker: str, days: int = 200) -> dict | None:
+    hist = yf.Ticker(ticker).history(period="1y", auto_adjust=False)
+    if hist is None or hist.empty:
+        return None
+    vol = hist["Volume"].tail(days)
+    nonzero = vol[vol > 0]
+    values = vol.tolist()
+    multiples: list[float] = []
+    for i in range(30, len(values)):
+        base = [x for x in values[i - 30:i] if x > 0]
+        if base:
+            multiples.append(values[i] / (sum(base) / len(base)))
+    return {
+        "ticker":      ticker,
+        "days":        len(vol),
+        "zero_days":   int((vol == 0).sum()),
+        "avg_vol":     float(nonzero.mean()) if len(nonzero) else 0.0,
+        "median_vol":  float(nonzero.median()) if len(nonzero) else 0.0,
+        "max_multiple": max(multiples) if multiples else float("nan"),
+        "n_over_5x":   sum(1 for m in multiples if m > 5),
+        "n_over_10x":  sum(1 for m in multiples if m > 10),
+    }
+
+
+def main() -> int:
+    print(f"{'TICKER':<7} {'AVG VOL':>14} {'MEDIAN VOL':>14} {'ZERO-DAYS':>9} "
+          f"{'MAX MULT':>9} {'>5x':>4} {'>10x':>5}  VERDICT")
+    print("-" * 80)
+    failed = False
+    for ticker in NEW_SYMBOLS + LEGACY_FUTURES:
+        s = volume_stats(ticker)
+        if s is None:
+            print(f"{ticker:<7} NO DATA RETURNED")
+            if ticker in ACTIVE_NEW:
+                failed = True
+            continue
+        is_new = ticker in ACTIVE_NEW
+        clean = s["zero_days"] == 0 and s["max_multiple"] < MAX_SANE_MULTIPLE
+        verdict = ("CLEAN" if clean else "ARTIFACT SIGNATURE") if is_new else (
+            "legacy (expected dirty)" if ticker in LEGACY_FUTURES else "info only")
+        if is_new and not clean:
+            failed = True
+        print(f"{s['ticker']:<7} {s['avg_vol']:>14,.0f} {s['median_vol']:>14,.0f} "
+              f"{s['zero_days']:>9} {s['max_multiple']:>8.1f}x {s['n_over_5x']:>4} "
+              f"{s['n_over_10x']:>5}  {verdict}")
+
+    print()
+    if failed:
+        print("FAIL: an active ETF symbol shows the artifact signature — "
+              "Layer-1 containment will guard it, but investigate before relying "
+              "on its volume metrics.")
+        return 1
+    print("PASS: all active ETF symbols show clean volume "
+          f"(no zero-days, max multiple < {MAX_SANE_MULTIPLE:.0f}x).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_etf_universe.py
+++ b/tests/test_etf_universe.py
@@ -1,0 +1,154 @@
+"""Tests for the metal ETF root-cause swap (Fix D): GC=F→GLD, SI=F→SLV,
+HG=F→COPX. ETFs have no contract rolls, so their volume is real and the v2
+vol_dist short gate genuinely applies to the metals again.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+from analyzers.volume_analyzer import analyze_volume
+from claude_advisor.prompts import SYSTEM_PROMPT
+from claude_advisor.signal_gates import apply_short_gates
+from config import ALL_TICKERS, COMMODITIES, TICKER_NAMES
+from config.ticker_manager import ORIGINAL_18
+from tracker.cluster_detector import detect_clusters
+from tracker.sectors import get_sector
+
+OLD_FUTURES = {"GC=F", "SI=F", "HG=F"}
+NEW_ETFS    = {"GLD", "SLV", "COPX"}
+
+
+# ── 9. Universe swap ──────────────────────────────────────────────────────────
+
+def test_universe_contains_etfs_not_futures():
+    assert NEW_ETFS <= set(COMMODITIES)
+    assert not (OLD_FUTURES & set(COMMODITIES))
+    assert not (OLD_FUTURES & set(ALL_TICKERS))
+    assert NEW_ETFS <= ORIGINAL_18
+    assert not (OLD_FUTURES & ORIGINAL_18)
+
+
+def test_active_tickers_state_swapped():
+    with open("config/active_tickers.json", encoding="utf-8") as fh:
+        state = json.load(fh)
+    permanent = set(state["permanent"])
+    assert NEW_ETFS <= permanent
+    assert not (OLD_FUTURES & permanent)
+
+
+# ── 11. Copper decision: COPX, consistently ──────────────────────────────────
+
+def test_copper_proxy_is_copx_everywhere():
+    """COPX chosen over CPER (CPER's volume is too thin for the volume-based
+    signal model). The choice must be consistent across config and sectors."""
+    assert "COPX" in COMMODITIES
+    assert "CPER" not in COMMODITIES
+    assert "CPER" not in ALL_TICKERS
+    assert "COPX" in TICKER_NAMES
+    assert get_sector("COPX") == "commodities_metals"
+
+
+def test_etf_display_names():
+    assert TICKER_NAMES["GLD"] == "Gold (GLD)"
+    assert TICKER_NAMES["SLV"] == "Silver (SLV)"
+    assert "Copper" in TICKER_NAMES["COPX"]
+
+
+# ── 12. Artifact flag dormant on normal ETF-like data ─────────────────────────
+
+def test_artifact_flag_dormant_on_normal_volume():
+    """GLD-like normal day (volume ≈ baseline) must not trip the flag."""
+    result = analyze_volume({"current_volume": 8_000_000, "avg_volume_30d": 7_500_000})
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "normal"
+
+
+def test_artifact_flag_dormant_on_real_news_spike():
+    """A genuine 4x news-day spike stays below the artifact threshold."""
+    result = analyze_volume({"current_volume": 30_000_000, "avg_volume_30d": 7_500_000})
+    assert result["data_quality"] == "ok"
+    assert result["classification"] == "anomalous"
+
+
+def test_artifact_flag_still_arms_on_artifact_signature():
+    """Safety net kept: a 40x multiple still trips suspicious_volume even on
+    the new symbols — if an ETF ever shows the signature, we want to see it."""
+    result = analyze_volume({"current_volume": 300_000_000, "avg_volume_30d": 7_500_000})
+    assert result["data_quality"] == "suspicious_volume"
+
+
+# ── 13. SECTOR_MAP: metals cluster under the new symbols ──────────────────────
+
+def test_new_metals_map_to_commodities_metals():
+    for t in NEW_ETFS:
+        assert get_sector(t) == "commodities_metals", t
+
+
+def test_legacy_futures_still_map_for_window_continuity():
+    """Old symbols stay mapped so signals files from before the swap keep
+    clustering during the rolling window and in backtests."""
+    for t in OLD_FUTURES:
+        assert get_sector(t) == "commodities_metals", t
+
+
+def test_metals_cluster_forms_under_new_symbols(tmp_path):
+    sigs = [
+        {"ticker": t, "classification": "bubble_forming",
+         "recommendation": "reduce_exposure", "confidence": 7}
+        for t in ("GLD", "SLV", "COPX")
+    ]
+    path = tmp_path / "signals_2026-06-10.json"
+    path.write_text(json.dumps({"date": "2026-06-10", "signals": sigs}))
+    clusters = detect_clusters(
+        days_window=5, logs_dir=str(tmp_path), reference_date=dt.date(2026, 6, 10)
+    )
+    assert len(clusters) == 1
+    assert clusters[0]["sector"] == "commodities_metals"
+    assert set(clusters[0]["tickers"]) == NEW_ETFS
+
+
+# ── 14. No stray functional references ────────────────────────────────────────
+
+def test_prompt_references_new_symbols():
+    assert "GLD, SLV, COPX" in SYSTEM_PROMPT
+    # The retired symbols must not be presented as the live commodity universe.
+    assert "GC=F, SI=F, CL=F, HG=F" not in SYSTEM_PROMPT
+
+
+def test_youtube_domain_keywords_cover_new_symbols():
+    from collectors.youtube_sentiment import _COMMODITY_DOMAIN
+    for t in NEW_ETFS:
+        assert t in _COMMODITY_DOMAIN, t
+
+
+# ── 15. The vol_dist short gate genuinely applies to metals again ─────────────
+
+def test_metal_with_real_distribution_can_reach_bubble_forming():
+    """A metal ETF with REAL vol_dist > 1.0 + sustained extension + non-fear
+    macro passes every reclassification gate — proving metals are no longer
+    auto-excluded from the short side."""
+    signal = {
+        "ticker": "GLD",
+        "classification": "bubble_forming",
+        "recommendation": "reduce_exposure",
+        "reasoning": "parabolic retail gold mania",
+        "confidence": 8,
+    }
+    results = [{
+        "ticker": "GLD",
+        "signals": {
+            "market": {"long_horizon": {
+                "volume_dist_ratio": 1.6,        # real distribution (no artifact)
+                "price_extension_200d": 0.85,
+                "sustained_days_60": 40,
+            }},
+            "velocity": {"z_score_200d": 3.2},
+        },
+    }]
+    apply_short_gates([signal], results, {"fear_greed": 75, "buffett": 180.0})
+    assert signal["classification"] == "bubble_forming"
+    assert signal["recommendation"] == "reduce_exposure"
+    assert signal["confidence"] == 8
+    assert "v2_gate" not in signal

--- a/tests/test_volume_artifact_containment.py
+++ b/tests/test_volume_artifact_containment.py
@@ -1,0 +1,345 @@
+"""Tests for the 2026-06-09 fixes: buy-confidence floor (Fix A), volume-artifact
+containment (Fix B), and null-data SKIP (Fix C).
+
+Real-data context (logs/2026-06-09.txt, logs/signals_2026-06-09.json):
+  - SI=F was emitted as actionable contrarian_buy at confidence 5/10, citing
+    "Volume 43.2x (possible artifact, but directional)" and vol_dist 58.84.
+  - GC=F 11.81x / SI=F 43.22x / HG=F 25.4x all carried the suspicious_volume
+    flag; GC=F vol_dist 11.00 and SI=F vol_dist 58.84 were pure roll artifacts.
+  - SPCX rendered RED with vol=nanx, z30=0, z200=0, RSI=n/a, no 200d history.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from analyzers.volume_quality import (
+    log_artifact_summary,
+    sanitize_volume_artifacts,
+)
+from claude_advisor.prompts import SYSTEM_PROMPT
+from claude_advisor.signal_gates import apply_short_gates, gate_signal
+from output.document_builder import get_alert_tier, get_tier_reason, is_null_data
+from utils.token_optimizer import compress_signals
+
+_DATE = dt.date(2026, 6, 9)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+def _signals(
+    vol_ratio=2.0,
+    vol_class="elevated",
+    data_quality="ok",
+    z30=0.5,
+    z200=0.5,
+    rsi=50.0,
+    vol_dist=0.8,
+    ext=0.1,
+    sustained=0,
+) -> dict:
+    return {
+        "market": {
+            "current_price": 100.0,
+            "daily_return_pct": 1.0,
+            "recent_news": [],
+            "long_horizon": {
+                "price_extension_200d": ext,
+                "sustained_days_60": sustained,
+                "return_6m": 0.1,
+                "acceleration_ratio": 0.2,
+                "volume_dist_ratio": vol_dist,
+                "drawdown_from_peak_2y": -0.05,
+                "days_since_peak_2y": 10,
+            },
+        },
+        "volume": {
+            "classification": vol_class,
+            "ratio": vol_ratio,
+            "data_quality": data_quality,
+        },
+        "velocity": {
+            "classification": "normal",
+            "z_score_30d": z30,
+            "z_score_200d": z200,
+            "direction": "up",
+            "macro_extreme": False,
+        },
+        "rsi": {"rsi": rsi, "classification": "normal"},
+        "sentiment": None,
+    }
+
+
+def _buy(ticker="SI=F", conf=5):
+    return {
+        "ticker": ticker,
+        "classification": "irrational_panic",
+        "recommendation": "contrarian_buy",
+        "reasoning": "test",
+        "confidence": conf,
+    }
+
+
+def _short(ticker="GC=F", conf=8):
+    return {
+        "ticker": ticker,
+        "classification": "bubble_forming",
+        "recommendation": "reduce_exposure",
+        "reasoning": "test",
+        "confidence": conf,
+    }
+
+
+# ── 1. Fix A: buy-confidence floor ────────────────────────────────────────────
+
+def test_buy_below_floor_downgraded_to_wait():
+    sig = _buy(conf=5)
+    gate_signal(sig, {}, {}, {"fear_greed": 10, "buffett": 200.0}, sector=None)
+    assert sig["recommendation"] == "wait"
+    assert sig["classification"] == "irrational_panic"   # observation survives
+    assert sig["v2_gate"]["rule"] == "buy_conf_floor"
+    assert sig["v2_gate"]["original_confidence"] == 5
+
+
+def test_buy_at_floor_stays_actionable():
+    sig = _buy(conf=7)
+    gate_signal(sig, {}, {}, {"fear_greed": 10, "buffett": 200.0}, sector=None)
+    assert sig["recommendation"] == "contrarian_buy"
+    assert "v2_gate" not in sig
+
+
+def test_buy_floor_applies_through_batch_path():
+    """apply_short_gates (the function main.py calls) enforces the floor."""
+    signals = [_buy("SI=F", 5), _buy("SOFI", 8)]
+    apply_short_gates(signals, [], {"fear_greed": 10})
+    by = {s["ticker"]: s for s in signals}
+    assert by["SI=F"]["recommendation"] == "wait"
+    assert by["SOFI"]["recommendation"] == "contrarian_buy"
+
+
+# ── 2. Fix B: artifact nulling ────────────────────────────────────────────────
+
+def test_artifact_nulls_vol_dist_and_preserves_raw(tmp_path):
+    s = _signals(vol_ratio=43.22, vol_class="extreme",
+                 data_quality="suspicious_volume", vol_dist=58.84)
+    flagged = sanitize_volume_artifacts("SI=F", s, _DATE, logs_dir=str(tmp_path))
+    assert flagged is True
+    lh = s["market"]["long_horizon"]
+    assert lh["volume_dist_ratio"] is None          # gate payload nulled
+    assert lh["raw_volume_dist_ratio"] == 58.84     # raw kept for the log/human
+    assert s["volume"]["artifact"] is True
+    assert s["volume"]["raw_ratio"] == 43.22
+
+
+def test_clean_ticker_untouched(tmp_path):
+    s = _signals(vol_ratio=2.0, data_quality="ok", vol_dist=1.4)
+    flagged = sanitize_volume_artifacts("NVDA", s, _DATE, logs_dir=str(tmp_path))
+    assert flagged is False
+    assert s["market"]["long_horizon"]["volume_dist_ratio"] == 1.4
+    assert "artifact" not in s["volume"]
+
+
+# ── 3. Fix B: artifact-poisoned vol_dist cannot pass the short gate ───────────
+
+def test_poisoned_vol_dist_cannot_pass_short_gate(tmp_path):
+    """A commodity with raw vol_dist 58.84 (pure artifact) + suspicious flag:
+    after containment the bubble short is reclassified to wait — the 58.84
+    can no longer wave it through the distribution gate."""
+    s = _signals(vol_ratio=43.22, vol_class="extreme",
+                 data_quality="suspicious_volume",
+                 vol_dist=58.84, ext=0.9, sustained=45, z200=3.0)
+    sanitize_volume_artifacts("SI=F", s, _DATE, logs_dir=str(tmp_path))
+
+    short = _short("SI=F", conf=8)
+    results = [{"ticker": "SI=F", "signals": s}]
+    apply_short_gates([short], results, {"fear_greed": 60, "buffett": 150.0})
+    assert short["recommendation"] == "wait"
+    assert short["classification"] == "institutional_rebalancing"
+    assert short["v2_gate"]["rule"] == "vol_dist"
+
+
+def test_unpoisoned_vol_dist_still_passes_short_gate():
+    """Control: the same setup WITHOUT the artifact flag still passes — the
+    gate itself is unchanged; only the data feeding it is sanitized."""
+    s = _signals(vol_ratio=3.0, vol_class="anomalous", data_quality="ok",
+                 vol_dist=1.4, ext=0.9, sustained=45, z200=3.0)
+    short = _short("XYZ", conf=8)
+    results = [{"ticker": "XYZ", "signals": s}]
+    apply_short_gates([short], results, {"fear_greed": 60, "buffett": 150.0})
+    assert short["recommendation"] == "reduce_exposure"
+
+
+# ── 4. Fix B: prompt instruction ──────────────────────────────────────────────
+
+def test_prompt_forbids_citing_nulled_volume():
+    assert "suspected data artifact" in SYSTEM_PROMPT
+    assert "UNRELIABLE and set to null" in SYSTEM_PROMPT
+    assert "Do not use them as evidence for any directional call" in SYSTEM_PROMPT
+    assert "price velocity (z-scores), RSI, long-horizon extension, and social signals only" in SYSTEM_PROMPT
+
+
+# ── 5. Fix B: artifact logging ────────────────────────────────────────────────
+
+def test_artifact_log_written(tmp_path):
+    s = _signals(vol_ratio=43.22, vol_class="extreme",
+                 data_quality="suspicious_volume", vol_dist=58.84)
+    sanitize_volume_artifacts("SI=F", s, _DATE, logs_dir=str(tmp_path))
+    log_artifact_summary(_DATE, ["SI=F"], logs_dir=str(tmp_path))
+
+    content = (tmp_path / "volume_artifacts.log").read_text()
+    assert "2026-06-09 | SI=F | raw_vol_multiple=43.22x | raw_vol_dist=58.84" in content
+    assert "2026-06-09 | SUMMARY | count=1 | tickers=SI=F" in content
+
+
+def test_artifact_log_suppressed_in_debug_mode(tmp_path):
+    s = _signals(vol_ratio=43.22, vol_class="extreme",
+                 data_quality="suspicious_volume", vol_dist=58.84)
+    flagged = sanitize_volume_artifacts(
+        "SI=F", s, _DATE, logs_dir=str(tmp_path), write_log=False
+    )
+    assert flagged is True                                  # nulling still applies
+    assert not (tmp_path / "volume_artifacts.log").exists() # but no state write
+
+
+# ── 6. Fix B: report rendering ────────────────────────────────────────────────
+
+def test_report_renders_investigation_flag(tmp_path):
+    s = _signals(vol_ratio=43.22, vol_class="extreme",
+                 data_quality="suspicious_volume", vol_dist=58.84)
+    sanitize_volume_artifacts("SI=F", s, _DATE, logs_dir=str(tmp_path))
+    body = compress_signals("SI=F", "Silver", s)
+
+    assert "VOLUME DATA UNRELIABLE" in body
+    assert "NEEDS INVESTIGATION" in body
+    assert "contract-roll artifact suspected" in body
+    # Volume line nulled in the classifier payload — no multiple to cite
+    assert "- Volume: n/a (suspected data artifact — excluded from analysis)" in body
+    assert "extreme (43.22x 30d avg)" not in body
+    # vol_dist line nulled too
+    assert "58.84" not in body
+    # The pre-existing DATA QUALITY badge is kept (raw value, human context)
+    assert "DATA QUALITY FLAG" in body
+
+
+def test_report_clean_ticker_renders_volume_normally():
+    s = _signals(vol_ratio=3.1, vol_class="anomalous", data_quality="ok")
+    body = compress_signals("NVDA", "Nvidia", s)
+    assert "- Volume: anomalous (3.1x 30d avg)" in body
+    assert "VOLUME DATA UNRELIABLE" not in body
+
+
+# ── 7. Fix C: null-data SKIP ──────────────────────────────────────────────────
+
+def _spcx_signals():
+    s = _signals(vol_ratio=float("nan"), vol_class="extreme", data_quality="ok",
+                 z30=0.0, z200=0.0, rsi=None, vol_dist=None)
+    s["market"]["long_horizon"]["price_extension_200d"] = None
+    return s
+
+
+def test_null_data_ticker_is_skip_not_red():
+    s = _spcx_signals()
+    assert is_null_data(s) is True
+    assert get_alert_tier(s) is None
+    assert "null data" in get_tier_reason(s)
+
+
+def test_real_extreme_volume_still_red():
+    """Control: a genuine extreme-volume ticker still triggers RED."""
+    s = _signals(vol_ratio=6.0, vol_class="extreme", data_quality="ok")
+    assert is_null_data(s) is False
+    assert get_alert_tier(s) == "red"
+
+
+def test_zero_z_with_real_volume_not_null_data():
+    s = _signals(vol_ratio=1.2, vol_class="normal", z30=0.0, z200=0.0)
+    assert is_null_data(s) is False
+
+
+# ── 8. Replay 2026-06-09 ──────────────────────────────────────────────────────
+
+def _replay_results(tmp_path):
+    """Reconstruct the five 2026-06-09 tickers with real logged values and run
+    them through the containment exactly as run_pipeline does."""
+    data = {
+        # ticker: (ratio, class, dq, z30, z200, rsi, vol_dist, ext, sustained)
+        "AAPL": (1.3, "normal", "ok", -2.6, -1.0, 35.0, 0.9, -0.05, 0),
+        "SPCX": (float("nan"), "extreme", "ok", 0.0, 0.0, None, None, None, None),
+        "GC=F": (11.81, "extreme", "suspicious_volume", -0.69, -0.72, 31.1, 11.00, -0.028, 0),
+        "SI=F": (43.22, "extreme", "suspicious_volume", -1.17, -1.06, 29.5, 58.84, -0.020, 3),
+        "HG=F": (25.4, "extreme", "suspicious_volume", 0.08, 0.09, 52.0, 0.15, 0.154, 0),
+    }
+    results = []
+    artifact_tickers = []
+    for ticker, (ratio, vc, dq, z30, z200, rsi, vd, ext, sus) in data.items():
+        s = _signals(vol_ratio=ratio, vol_class=vc, data_quality=dq,
+                     z30=z30, z200=z200, rsi=rsi, vol_dist=vd,
+                     ext=ext, sustained=sus)
+        if ext is None:
+            s["market"]["long_horizon"]["price_extension_200d"] = None
+        if sanitize_volume_artifacts(ticker, s, _DATE, logs_dir=str(tmp_path)):
+            artifact_tickers.append(ticker)
+        results.append({"ticker": ticker, "signals": s})
+    if artifact_tickers:
+        log_artifact_summary(_DATE, artifact_tickers, logs_dir=str(tmp_path))
+    return results, artifact_tickers
+
+
+def _replay_signals():
+    """The actual classified signals from logs/signals_2026-06-09.json."""
+    return [
+        {"ticker": "AAPL", "classification": "ambiguous",
+         "recommendation": "wait", "confidence": 3},
+        {"ticker": "SPCX", "classification": "ambiguous",
+         "recommendation": "wait", "confidence": 1},
+        {"ticker": "GC=F", "classification": "institutional_rebalancing",
+         "recommendation": "wait", "confidence": 4},
+        _buy("SI=F", 5),
+        {"ticker": "HG=F", "classification": "institutional_rebalancing",
+         "recommendation": "wait", "confidence": 4},
+    ]
+
+
+def test_replay_20260609_zero_actionable(tmp_path):
+    results, artifact_tickers = _replay_results(tmp_path)
+    signals = _replay_signals()
+
+    # Macro on 2026-06-09: Fear & Greed 10 (extreme fear).
+    apply_short_gates(signals, results, {"fear_greed": 10, "buffett": 200.0})
+
+    by = {s["ticker"]: s for s in signals}
+    # SI=F conf-5 buy is downgraded — no longer actionable.
+    assert by["SI=F"]["recommendation"] == "wait"
+    assert by["SI=F"]["v2_gate"]["rule"] == "buy_conf_floor"
+
+    actionable = [s for s in signals
+                  if s["recommendation"] in ("contrarian_buy", "reduce_exposure")]
+    assert actionable == []          # 0 actionable for the day
+
+    # All three metals flagged + logged.
+    assert artifact_tickers == ["GC=F", "SI=F", "HG=F"]
+    log = (tmp_path / "volume_artifacts.log").read_text()
+    for t in ("GC=F", "SI=F", "HG=F"):
+        assert f"| {t} |" in log
+    assert "SUMMARY | count=3" in log
+
+    # SPCX is SKIP, not RED.
+    spcx = next(r for r in results if r["ticker"] == "SPCX")
+    assert get_alert_tier(spcx["signals"]) is None
+
+    # Metals keep their AMBER tier (tier-suppression path unchanged) but their
+    # vol_dist is nulled so no poisoned value can reach the short gate.
+    for t in ("GC=F", "SI=F", "HG=F"):
+        r = next(x for x in results if x["ticker"] == t)
+        assert get_alert_tier(r["signals"]) == "amber"
+        assert r["signals"]["market"]["long_horizon"]["volume_dist_ratio"] is None
+
+
+def test_replay_20260609_hypothetical_poisoned_short_blocked(tmp_path):
+    """Even if the classifier HAD issued a bubble short on SI=F (vol_dist
+    58.84 would sail through > 1.0), containment blocks it."""
+    results, _ = _replay_results(tmp_path)
+    short = _short("SI=F", conf=8)
+    apply_short_gates([short], results, {"fear_greed": 60, "buffett": 150.0})
+    assert short["recommendation"] == "wait"
+    assert short["v2_gate"]["rule"] == "vol_dist"

--- a/tracker/sectors.py
+++ b/tracker/sectors.py
@@ -16,9 +16,13 @@ SECTOR_MAP = {
         "AAPL", "MSFT", "GOOGL", "GOOG", "META", "AMZN", "TSLA",
         "NFLX", "ORCL", "CRM",
     ],
+    # Active metal symbols are the ETF proxies (GLD/SLV/COPX — see
+    # config/__init__.py). The retired front-month futures symbols stay mapped
+    # so historical signals files within the rolling cluster window and
+    # backtests keep clustering correctly.
     "commodities_metals": [
+        "GLD", "SLV", "COPX", "CPER", "GDX", "GDXJ",
         "GC=F", "SI=F", "HG=F", "PL=F", "PA=F",
-        "GLD", "SLV", "GDX", "GDXJ",
     ],
     "energy": [
         "CL=F", "NG=F", "BZ=F", "RB=F",

--- a/utils/token_optimizer.py
+++ b/utils/token_optimizer.py
@@ -185,12 +185,27 @@ def compress_signals(ticker: str, name: str, signals: dict) -> str:
 
     macro_flag = " ⚠ macro_extreme" if p.get("macro_extreme") else ""
 
+    # Volume-artifact containment (analyzers/volume_quality.py): when the
+    # artifact flag fires, the volume multiple is removed from the classifier
+    # payload entirely (raw value survives only in the badge and the artifact
+    # log) and the loud investigation flag is rendered for the human reader.
+    artifact = bool(v.get("artifact")) or v.get("data_quality") == "suspicious_volume"
     dq_flag = ""
-    if v.get("data_quality") == "suspicious_volume":
+    if artifact:
+        raw_ratio = v.get("raw_ratio", v.get("ratio"))
         dq_flag = (
-            f"⚠ DATA QUALITY FLAG: This ticker's volume multiple ({v['ratio']}x) exceeds normal"
-            f" range and may be a data artifact. Weight volume evidence accordingly.\n\n"
+            f"⚠ DATA QUALITY FLAG: This ticker's volume multiple ({raw_ratio}x) exceeds normal"
+            f" range and may be a data artifact. Weight volume evidence accordingly.\n"
+            f"⚠ VOLUME DATA UNRELIABLE — metrics excluded from analysis. yfinance "
+            f"front-month contract-roll artifact suspected. NEEDS INVESTIGATION/FIX. "
+            f"See backtests/VOLUME_FIX*.md and logs/volume_artifacts.log\n\n"
         )
+
+    volume_line = (
+        "- Volume: n/a (suspected data artifact — excluded from analysis)"
+        if artifact
+        else f"- Volume: {v['classification']} ({v['ratio']}x 30d avg)"
+    )
 
     # Long-horizon context (strategy v2, observation mode).
     # These signals are for context only — do not use them as classification
@@ -203,7 +218,7 @@ def compress_signals(ticker: str, name: str, signals: dict) -> str:
         f"{dq_flag}"
         f"Asset: {ticker} ({name})\n\n"
         f"Market signals:\n"
-        f"- Volume: {v['classification']} ({v['ratio']}x 30d avg)\n"
+        f"{volume_line}\n"
         f"- Price velocity: {p['classification']} "
         f"(z_30d: {p['z_score_30d']}, z_200d: {p['z_score_200d']}, "
         f"direction: {p['direction']}, macro_extreme: {p.get('macro_extreme', False)})"


### PR DESCRIPTION
# Buy-Floor + Artifact-Volume Containment + Volume-Health Flag + ETF Root-Cause Fix

Two layers, two commits, separable in history:
- **Layer 1** (`fix(layer1)`, commit 1): Fixes A/B/C — make the system safe against bad volume regardless of source. Independently verified (Gate 1 below).
- **Layer 2** (`fix(layer2)`, commit 2): Fix D — replace metal front-month futures with ETF proxies so commodity volume becomes real and gate-usable again.

All 144 tests pass (30 new).

---

## 1. Diff summary per fix

### Fix A — contrarian_buy ≥ 7 floor, code-enforced
- `claude_advisor/signal_gates.py`: new **rule 0** in `gate_signal()` — a `contrarian_buy` below `MIN_LONG_CONFIDENCE` (7) is downgraded to `wait` with a `v2_gate {action: "downgraded", rule: "buy_conf_floor"}` annotation. Classification is preserved (it survives as an observation). Symmetric with the existing short floor (6) / fear-cap (5) pattern; `apply_short_gates` logs and counts downgrades.

### Fix B — artifact-flagged volume: null, exclude, flag, log
- **New `analyzers/volume_quality.py`**: `sanitize_volume_artifacts()` — when `data_quality == "suspicious_volume"`, nulls `market.long_horizon.volume_dist_ratio` (the v2 PRIMARY short-gate input; a null **fails** the `> 1.0` gate) and marks `volume["artifact"]=True`; raw values preserved only for the badge and the log. **No correction attempted — poisoned data is excluded, not adjusted.**
- `main.py run_pipeline()`: calls the sanitizer per ticker, before anything downstream can read the metrics; writes `logs/volume_artifacts.log` (per-ticker raw values + per-run `SUMMARY | count=N` line for frequency tracking). Suppressed in `--debug` (no state writes).
- `utils/token_optimizer.py`: classifier payload renders `- Volume: n/a (suspected data artifact — excluded from analysis)` — no multiple to cite; renders the new loud flag (existing DATA QUALITY badge kept, this adds to it).
- `claude_advisor/prompts.py`: new mandatory rule — nulled volume metrics must not be used as evidence; *"possible artifact, but directional" is explicitly forbidden reasoning*.
- `delivery/digest_builder.py`: actionable rows for affected tickers get "⚠ (volume data excluded — unreliable)".

### Fix C — null-data tickers → SKIP
- `output/document_builder.py`: new `is_null_data()` — NaN/None volume ratio AND z30 == 0 AND z200 == 0 AND no 200d history → tier `None` (SKIP), with an explicit `get_tier_reason`. Previously NaN volume read as classification "extreme" through failed float comparisons and solo-triggered RED (SPCX daily).

### Fix D — metal ETF proxies (root cause)
- `GC=F → GLD`, `SI=F → SLV`, `HG=F → COPX` in `config/__init__.py` (COMMODITIES + TICKER_NAMES with friendly labels "Gold (GLD)" etc.), `config/ticker_manager.py` (ORIGINAL_18), `config/active_tickers.json` (permanent tier). ETFs have no contract rolls → no stitched volume → the artifact mechanism is structurally absent and the v2 `vol_dist > 1.0` gate genuinely applies to the metals again.
- `tracker/sectors.py`: COPX/CPER added to `commodities_metals`; retired futures stay mapped so pre-swap signals files keep clustering through the rolling window and in backtests.
- `collectors/youtube_sentiment.py`: relevance keywords for GLD/SLV/COPX.
- New `scripts/validate_etf_volume.py`: 200-day clean-volume validation (see §4).
- Layer-1 containment stays armed as a safety net (per spec step 7).

**COPPER DECISION: COPX, not CPER.** Volume is this radar's primary signal family. CPER is a futures-index grantor trust that trades very thin (frequently low-six-figure shares/day) — too thin for a meaningful `volume_dist` or volume-multiple signal — while COPX (Global X Copper Miners) is reliably liquid at millions of shares/day. Trade-off: COPX carries equity beta on top of the metal; the system prompt now states this explicitly. **Caveat:** this sandbox's egress allowlist blocks all finance data hosts (Yahoo/stooq → HTTP 403), so I could not pull live ADV numbers from here; the decision rests on the liquidity profile of the two funds and is made robust to that uncertainty — `scripts/validate_etf_volume.py` prints CPER's numbers alongside the active symbols on every run, and revisiting the choice is a one-line config swap. Test 11 (`test_copper_proxy_is_copx_everywhere`) pins consistency.

---

## 2. Grep evidence — each fix is in the production call chain

**Fix A** — `main.py → apply_short_gates → gate_signal rule 0`:
```
main.py:652:        from claude_advisor.signal_gates import apply_short_gates
main.py:654:        apply_short_gates(_classified_signals, results, _macro_for_gates)
claude_advisor/signal_gates.py:148:    # ── Rule 0: buy-confidence floor ─────────────
claude_advisor/signal_gates.py:159:                "rule": "buy_conf_floor",
```

**Fix B** — `main.py run_pipeline → sanitize_volume_artifacts`; gates read the nulled field; renderer/digest/prompt:
```
main.py:40: from analyzers.volume_quality import log_artifact_summary, sanitize_volume_artifacts
main.py:170:        if sanitize_volume_artifacts(
main.py:178:        log_artifact_summary(date, artifact_tickers, logs_dir=LOGS_DIR)
claude_advisor/signal_gates.py:175:    vol_dist  = lh.get("volume_dist_ratio")   # ← the nulled field
utils/token_optimizer.py:199:  f"⚠ VOLUME DATA UNRELIABLE — metrics excluded from analysis. yfinance "
delivery/digest_builder.py:78:    artifact_tickers = {
delivery/digest_builder.py:191:            if ticker in artifact_tickers:
claude_advisor/prompts.py:59: - If a ticker's volume is flagged as a suspected data artifact, ... set to null. Do not use them as evidence ...
```

**Fix C** — `main.py → get_alert_tier → is_null_data` (main.py imports `get_alert_tier` at line 61 and calls it at 188/199/231/263; digest counts use it too):
```
output/document_builder.py:33: def is_null_data(signals: dict) -> bool:
output/document_builder.py:60:     if is_null_data(signals):   # inside get_alert_tier
main.py:61: from output.document_builder import get_alert_tier, get_tier_reason, write_document
main.py:188:    alert_tickers = [r["ticker"] for r in results if get_alert_tier(r["signals"])]
```

**Fix D** — `main.py:521 get_active_tickers()` → `config/active_tickers.json` permanent tier (now GLD/SLV/COPX), fallback `ORIGINAL_18`:
```
config/__init__.py:34:    "GLD",    # Gold (SPDR Gold Shares — replaces GC=F)
config/__init__.py:37:    "COPX",   # Copper miners (Global X — replaces HG=F; CPER too thin)
config/ticker_manager.py:40: # Metals swapped to ETF proxies (GLD/SLV/COPX) — see config/__init__.py.
main.py:521:        tickers = get_active_tickers()
```

---

## 3. Verification Gate 1 — 2026-06-09 replay (Test 8 output)

Replayed the actual `logs/signals_2026-06-09.json` through the new pipeline (containment + gates), with the real per-ticker values from `logs/2026-06-09.txt`:

```
=== REPLAY 2026-06-09 (real classified signals through new gates) ===
 AAPL:            wait/conf3 ->            wait/conf3
 SPCX:            wait/conf1 ->            wait/conf1  tier=SKIP
 GC=F:            wait/conf4 ->            wait/conf4  tier=amber
 SI=F:  contrarian_buy/conf5 ->            wait/conf5  tier=amber  [buy_conf_floor: contrarian_buy conf=5 < 7 → wait (observation, not actionable)]
 HG=F:            wait/conf4 ->            wait/conf4  tier=amber

Actionable count: 0  (was 1: SI=F contrarian_buy conf 5)
SPCX tier: None | reason: SKIP: null data — NaN volume, zero z-scores, no 200d history (pre-IPO / dead ticker, no real signal)
```

- ✅ SI=F no longer actionable — fails the conf-7 floor; its volume is also nulled (belt and braces: a hypothetical bubble *short* on SI=F with raw vol_dist 58.84 is blocked by the nulled gate input — `test_replay_20260609_hypothetical_poisoned_short_blocked`)
- ✅ GC=F / SI=F / HG=F flagged + logged; their vol_dist (raw 11.00 / 58.84 / 0.15) is `None` in the gate payload
- ✅ SPCX → SKIP, out of the RED count
- ✅ 0 actionable for the day
- ✅ Metals keep AMBER (tier-suppression path deliberately unchanged)
- ✅ All pre-existing tests pass (Layer 1 alone: 131/131)

## 4. Verification Gate 2 — ETF swap

Structural items verified by tests: universe + state file swapped (test 9), copper consistency (test 11), artifact flag dormant on normal/news-day volume but still arming at 40x as a safety net (test 12), `commodities_metals` cluster forms under GLD/SLV/COPX and legacy symbols still map for window continuity (test 13), prompt references the new symbols and no stray functional references remain (test 14, plus the full grep audit below), and a synthetic GLD with **real** vol_dist 1.6 + ext +85% + 40/60 sustained + greed macro now reaches `bubble_forming` — metals are no longer auto-excluded from the short side (test 15).

**Live before/after volume table (Test 10): could not be produced from this environment.** The execution sandbox's network policy blocks all market-data hosts (`query1.finance.yahoo.com` and fallbacks → HTTP 403 "Host not in allowlist"), so no yfinance pull is possible here. The committed `scripts/validate_etf_volume.py` produces exactly this table (200-day avg/median volume, zero-days, max 30d-baseline multiple, >5x/>10x counts, CLEAN/ARTIFACT verdict, with GC=F/SI=F/HG=F as the dirty baseline) and exits 1 if any active symbol shows the artifact signature — run it locally or in Actions (the daily workflow already talks to Yahoo) as part of the merge checklist below. Post-swap, `logs/volume_artifacts.log` going quiet for the metals on daily runs is the operational confirmation.

**Old-symbol grep audit (every remaining match + disposition):**
| Location | Disposition |
|---|---|
| `config/__init__.py` legacy TICKER_NAMES block + comments | Deliberate — display names for historical logs ("Gold (futures, retired)") |
| `tracker/sectors.py` commodities_metals | Deliberate — cluster continuity for pre-swap signals files in the rolling window |
| `collectors/youtube_sentiment.py` keyword map tail + few-shot examples | Deliberate — legacy CLI runs; prompt examples are illustrative |
| `backtesting/historical/main.py`, `.claude/skills/historical-backtest` | Historical replay periods — futures symbols are correct for past dates |
| `scripts/validate_etf_volume.py` LEGACY_FUTURES | The before/after comparison itself |
| `analyzers/volume_quality.py`, `signal_gates.py` docstrings, `output/weekly_summary.py` comment | Incident documentation |
| `tests/*` | Replays of historical incidents (2026-06-09, May artifacts) |
| `logs/`, `docs/`, `backtests/` | Append-only archive |

## 5. Sample `logs/volume_artifacts.log` lines (Layer 1, pre-swap)

```
2026-06-09 | GC=F | raw_vol_multiple=11.81x | raw_vol_dist=11.00 | metrics nulled (suspected contract-roll artifact)
2026-06-09 | SI=F | raw_vol_multiple=43.22x | raw_vol_dist=58.84 | metrics nulled (suspected contract-roll artifact)
2026-06-09 | HG=F | raw_vol_multiple=25.40x | raw_vol_dist=0.15 | metrics nulled (suspected contract-roll artifact)
2026-06-09 | SUMMARY | count=3 | tickers=GC=F,SI=F,HG=F
```

## 6. VOLUME DATA UNRELIABLE flag — as rendered in the full report

```
⚠ DATA QUALITY FLAG: This ticker's volume multiple (43.22x) exceeds normal range and may be a data artifact. Weight volume evidence accordingly.
⚠ VOLUME DATA UNRELIABLE — metrics excluded from analysis. yfinance front-month contract-roll artifact suspected. NEEDS INVESTIGATION/FIX. See backtests/VOLUME_FIX*.md and logs/volume_artifacts.log

Asset: SI=F (Silver)

Market signals:
- Volume: n/a (suspected data artifact — excluded from analysis)
- Price velocity: normal (z_30d: -1.17, z_200d: -1.06, direction: down, macro_extreme: False)
- RSI-14: 29.5 (oversold)
```
(Digest rows for affected actionable signals additionally show "⚠ (volume data excluded — unreliable)".)

## 7. What did NOT change
v2 gates themselves (vol_dist > 1.0, sustained extension, macro cap, AI-hardware rule — `test_unpoisoned_vol_dist_still_passes_short_gate` is the control), long-side irrational_panic logic, 30d hold, -25% stop, sizing, cluster-boost mechanics, report/digest layout (beyond the new flag + friendly labels), and the existing DATA QUALITY badge + RED tier-suppression (extended, not replaced).

**Remaining-futures note (recorded TODO in `config/__init__.py`):** CL=F / ZS=F / NG=F are still front-month and rely on the Layer-1 containment around rolls; candidate proxies if their volume ever needs to be gate-usable: USO, DBA/SOYB, UNG.

## 8. Merge checklist
- [ ] Click **"Merge pull request"** in GitHub UI (not Close)
- [ ] After merge: `git log origin/main --oneline -3` shows this commit at top
- [ ] Run `python scripts/validate_etf_volume.py` (locally or in Actions) — confirm GLD/SLV/COPX are CLEAN (max multiple in sane range, no zero-days) and capture the before/after table vs GC=F/SI=F/HG=F
- [ ] Trigger one manual run; confirm: SI=F-style sub-7 buys are not actionable, metals show real volume (not 40x), no VOLUME UNRELIABLE flag firing on GLD/SLV, `logs/volume_artifacts.log` quiet for the metals
- [ ] Confirm SPCX is SKIP (out of the RED count)
- [ ] Confirm the `commodities_metals` cluster still forms under GLD/SLV/COPX

https://claude.ai/code/session_01JwtbZn6GqZM3PhvTd1zvgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwtbZn6GqZM3PhvTd1zvgp)_